### PR TITLE
add validate api for totp

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -36,5 +36,16 @@ return [
 			'url' => '/settings/verifyNewSecret',
 			'verb' => 'POST'
 		],
+	],
+	'ocs' => [
+		[
+			'name' => 'totp_api#validateKey',
+			'url' => '/api/v1/validate/{uid}/{key}',
+			'verb' => 'GET',
+			'requirements' => [
+				'uid' => '.+',
+				'key' => '.+'
+			]
+		]
 	]
 ];

--- a/lib/Controller/TotpApiController.php
+++ b/lib/Controller/TotpApiController.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Controller;
+
+use OCA\TwoFactor_Totp\Exception\NoTotpSecretFoundException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\ILogger;
+use \OCP\IRequest;
+use \OCP\IUserManager;
+use OCA\TwoFactor_Totp\Service\ITotp;
+
+class TotpApiController extends OCSController {
+
+	/** @var ITotp */
+	private $totp;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(
+		$appName,
+		IRequest $request,
+		ITotp $totp,
+		IUserManager $userManager,
+		ILogger $logger
+	) {
+		parent::__construct($appName, $request);
+		$this->totp = $totp;
+		$this->userManager = $userManager;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @CORS
+	 * @NoCSRFRequired
+	 *
+	 * @param string $uid
+	 * @param string $key 6 digits numeric time-based one time password.
+	 * @return DataResponse
+	 */
+	public function validateKey($uid, $key) {
+		$user = $this->userManager->get($uid);
+		if ($user !== null) {
+			try {
+				return new DataResponse(['data' => ['result' => $this->totp->validateKey($user, $key)]]);
+			} catch (NoTotpSecretFoundException $e) {
+				$this->logger->logException($e);
+			}
+		}
+		return new DataResponse(
+			[
+				'statuscode' => 404,
+				'data' => ['result' => false]
+			],
+			Http::STATUS_NOT_FOUND
+		);
+	}
+}

--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -90,7 +90,7 @@ class TotpProvider implements IProvider {
 	 * @param string $challenge
 	 */
 	public function verifyChallenge(IUser $user, $challenge) {
-		return $this->totp->validateSecret($user, $challenge);
+		return $this->totp->validateKey($user, $challenge);
 	}
 
 	/**

--- a/lib/Service/ITotp.php
+++ b/lib/Service/ITotp.php
@@ -22,6 +22,7 @@
 
 namespace OCA\TwoFactor_Totp\Service;
 
+use OCA\TwoFactor_Totp\Exception\NoTotpSecretFoundException;
 use OCA\TwoFactor_Totp\Exception\TotpSecretAlreadySet;
 use OCP\IUser;
 
@@ -46,9 +47,11 @@ interface ITotp {
 
 	/**
 	 * @param IUser $user
-	 * @param string $key
+	 * @param string $key 6 digits numeric time-based one time password.
+	 * @return boolean If key is correct
+	 * @throws NoTotpSecretFoundException
 	 */
-	public function validateSecret(IUser $user, $key);
+	public function validateKey(IUser $user, $key);
 
 	/**
 	 * @param IUser $user

--- a/lib/Service/Totp.php
+++ b/lib/Service/Totp.php
@@ -92,7 +92,7 @@ class Totp implements ITotp {
 	 * @param string $key
 	 */
 	public function verifySecret(IUser $user, $key) {
-		if ($this->validateSecret($user, $key) === true) {
+		if ($this->validateKey($user, $key) === true) {
 			$dbSecret = $this->secretMapper->getSecret($user);
 			$dbSecret->setVerified(true);
 			$this->secretMapper->update($dbSecret);
@@ -104,8 +104,10 @@ class Totp implements ITotp {
 	/**
 	 * @param IUser $user
 	 * @param string $key
+	 * @return boolean
+	 * @throws NoTotpSecretFoundException
 	 */
-	public function validateSecret(IUser $user, $key) {
+	public function validateKey(IUser $user, $key) {
 		try {
 			$dbSecret = $this->secretMapper->getSecret($user);
 		} catch (DoesNotExistException $ex) {

--- a/tests/unit/Controller/TotpApiControllerTest.php
+++ b/tests/unit/Controller/TotpApiControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Unit\Controller;
+
+use OC\OCS\Result;
+use OCA\TwoFactor_Totp\Controller\TotpApiController;
+use OCA\TwoFactor_Totp\Exception\NoTotpSecretFoundException;
+use OCA\TwoFactor_Totp\Service\ITotp;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use Test\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class TotpApiControllerTest extends TestCase {
+
+	/** @var IRequest | PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var IUserManager | PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+
+	/** @var IUser | PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+
+	/** @var ITotp | PHPUnit_Framework_MockObject_MockObject */
+	private $totp;
+
+	/** @var ILogger | PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
+	/** @var TotpApiController */
+	private $controller;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->user = $this->createMock(IUser::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->totp = $this->createMock(ITotp::class);
+		$this->logger = $this->createMock(ILogger::class);
+
+		$this->controller = new TotpApiController(
+			'twofactor_totp',
+			$this->request, $this->totp,
+			$this->userManager,
+			$this->logger
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestValidateKey
+	 *
+	 * @param string $uid
+	 * @param boolean $result
+	 */
+	public function testValidateKey($uid, $result) {
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($uid)
+			->will($this->returnValue($this->user));
+		$this->totp->expects($this->once())
+			->method('validateKey')
+			->with($this->user, '111111')
+			->will($this->returnValue($result));
+
+		$expected =  new DataResponse(['data' => ['result' => $result]]);
+		$this->assertEquals($expected, $this->controller->validateKey($uid, '111111'));
+	}
+
+	public function dataTestValidateKey() {
+		return [
+			['testuser', false],
+			['testuser', true],
+		];
+	}
+
+	public function testValidateKeyUserNotExist() {
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('notexist')
+			->will($this->returnValue(null));
+		$expected =  new DataResponse(
+			[
+				'statuscode' => 404,
+				'data' => ['result' => false]
+			],
+			Http::STATUS_NOT_FOUND
+		);
+		$this->assertEquals($expected, $this->controller->validateKey('notexist', '111111'));
+	}
+
+	public function testValidateKeySecretNotExist() {
+		$exception = new NoTotpSecretFoundException();
+		$this->user = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('testuser')
+			->will($this->returnValue($this->user));
+		$this->totp->expects($this->once())
+			->method('validateKey')
+			->with($this->user, '111111')
+			->will($this->throwException($exception));
+		$this->logger->expects($this->once())
+			->method('logException')
+			->with($exception);
+		$expected =  new DataResponse(
+			[
+				'statuscode' => 404,
+				'data' => ['result' => false]
+			],
+			Http::STATUS_NOT_FOUND
+		);
+		$this->assertEquals($expected, $this->controller->validateKey('testuser', '111111'));
+	}
+}

--- a/tests/unit/Provider/TotpProviderTest.php
+++ b/tests/unit/Provider/TotpProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Tests\Provider;
+
+use OCA\TwoFactor_Totp\Provider\TotpProvider;
+use OCA\TwoFactor_Totp\Service\ITotp;
+use OCP\IL10N;
+use OCP\IUser;
+use Test\TestCase;
+
+/**
+ * Class TotpTest
+ */
+class TotpProviderTest extends TestCase {
+
+	/** @var ITotp | \PHPUnit_Framework_MockObject_MockObject  $totp */
+	private $totp;
+
+	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	private $l;
+
+	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+
+	/** @var TotpProvider $totpProvider */
+	private $totpProvider;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->totp = $this->createMock(ITotp::class);
+		$this->l = $this->createMock(IL10N::class);
+		$this->user = $this->createMock(IUser::class);
+
+		$this->totpProvider = new TotpProvider($this->totp, $this->l);
+	}
+
+	public function testVerifyChallange() {
+		$this->totp->expects($this->once())
+			->method('validateKey')
+			->with($this->user, '111111');
+		$this->totpProvider->verifyChallenge($this->user, '111111');
+	}
+}

--- a/tests/unit/Service/TotpTest.php
+++ b/tests/unit/Service/TotpTest.php
@@ -64,7 +64,7 @@ class TotpTest extends TestCase {
 	 * @param boolean $validationResult
 	 * @param boolean $expectedResult
 	 */
-	public function testValidateSecret($lastKey, $key, $validationResult, $expectedResult) {
+	public function testValidateKey($lastKey, $key, $validationResult, $expectedResult) {
 		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user  */
 		$user = $this->createMock(IUser::class);
 		$dbSecret = $this
@@ -96,7 +96,7 @@ class TotpTest extends TestCase {
 				->method('update')
 				->with($dbSecret);
 		}
-		$this->assertEquals($this->totp->validateSecret($user, $key), $expectedResult);
+		$this->assertEquals($this->totp->validateKey($user, $key), $expectedResult);
 	}
 
 	public function validationProvider() {
@@ -117,6 +117,6 @@ class TotpTest extends TestCase {
 			->with($user)
 			->will($this->throwException(new DoesNotExistException('')));
 		$this->expectException(NoTotpSecretFoundException::class);
-		$this->totp->validateSecret($user, 'testkey');
+		$this->totp->validateKey($user, 'testkey');
 	}
 }


### PR DESCRIPTION
add OCS API for TOTP validation. Implementation of #29. @Touchwoody please test.

## Open tasks before release
- [ ] Needs documentation

## Usage

* **URL**
/ocs/v1.php/apps/twofactor_totp/api/v1/validate/:user_id/:key?format=json

* **Example test query for curl **
``
curl -u admin:pass 'http://base_url/ocs/v1.php/apps/twofactor_totp/api/v1/validate/{user_id}/{key}?format=json'
``


* **Method:**
  `GET`
  
*  **URL Params**
   **Required:**
   `user_id=[string]`
   `key=[string]`
```

* **Success Response:**
{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"result":true}}}
 
* **Fail Response:**
{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"result":false}}}

* **User or Secret Not Found Response:**
{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"OK","totalitems":"","itemsperpage":""},"data":{"result":false}}}