### PR TITLE
add commands to change verified state of secret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.2
 env:
   global:
-    - CORE_BRANCH=master
+    - CORE_BRANCH=stable10
     - PHP_COVERAGE=FALSE
   matrix:
     - DB=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ cache:
     - "$HOME/.npm"
     - "$HOME/.cache/bower"
 before_install:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.4' ]; then curl -s -o $HOME/.phpenv/versions/5.4/bin/phpunit
-    https://phar.phpunit.de/phpunit-4.8.9.phar; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.4' ]; then chmod +x $HOME/.phpenv/versions/5.4/bin/phpunit;
-    fi"
   - composer self-update
   - composer install
   - wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh
@@ -41,7 +37,7 @@ before_script:
 script:
   - find . -name \*.php -not -path './vendor/*' -exec php -l "{}" \;
   - cd tests
-  - phpunit --configuration phpunit.xml
+  - ../../../lib/composer/phpunit/phpunit/phpunit --configuration phpunit.xml
   - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then wget https://scrutinizer-ci.com/ocular.phar;
     fi
   - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then php ocular.phar code-coverage:upload --format=php-clover

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,6 +22,9 @@ This extension provides the most simple way to add a second factor to user login
 	<settings>
 		<personal>OCA\TwoFactor_Totp\Settings\PersonalPanel</personal>
 	</settings>
+	<commands>
+		<command>OCA\TwoFactor_Totp\Command\SetSecretVerificationStatusCommand</command>
+	</commands>
 
 	<dependencies>
 		<owncloud min-version="10.0" max-version="10.0" />

--- a/lib/Command/SetSecretVerificationStatusCommand.php
+++ b/lib/Command/SetSecretVerificationStatusCommand.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Command;
+
+use InvalidArgumentException;
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SetSecretVerificationStatusCommand extends Command {
+
+	/** @var TotpSecretMapper */
+	private $secretMapper;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(
+		TotpSecretMapper $secretMapper,
+		IUserManager $userManager
+	) {
+		parent::__construct();
+		$this->secretMapper = $secretMapper;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('twofactor_totp:set-secret-verification-status')
+			->setDescription(
+				'Set secret verification status of specified users or all users'
+			)
+			->addArgument(
+				'set-verified',
+				InputArgument::REQUIRED,
+				'Secret verification status to set. (true or false)'
+			)
+			->addOption(
+				'all',
+				null,
+				InputOption::VALUE_NONE,
+				'Will affect all users that use TOTP'
+			)
+			->addOption(
+				'uid',
+				'u',
+				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+				'The user\'s uid is used. This option can be used as --uid "Alice" --uid "Bob"'
+			);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		try {
+			$options = $this->parseInput($input);
+		} catch (InvalidArgumentException $e) {
+			$message = $e->getMessage();
+			$output->writeln("<error>$message</error>");
+			return 1;
+		}
+		$status = $options['status'];
+		if ($status === true) {
+			$commandActionString = 'verified';
+		} else {
+			$commandActionString = 'unverified';
+		}
+
+		if ($options['uids'] === 'all') {
+			$this->secretMapper->setAllSecretsVerificationStatus($status);
+			$output->writeln("<info>The status of all TOTP secrets has been set to $commandActionString</info>");
+			return 0;
+		}
+		foreach ($options['uids'] as $uid) {
+			try {
+				$user = $this->userManager->get($uid);
+				if(!$user) {
+					$output->writeln("<error>User $uid does not exist</error>");
+					continue;
+				}
+				$dbSecret = $this->secretMapper->getSecret($user);
+				$dbSecret->setVerified($options['status']);
+				$this->secretMapper->update($dbSecret);
+				$output->writeln("<info>The secret of $uid is $commandActionString</info>");
+			} catch (DoesNotExistException $ex) {
+				$output->writeln("<error>User has no secret: $uid</error>");
+				return 1;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @return array
+	 */
+	protected function parseInput(InputInterface $input) {
+		$status = $input->getArgument('set-verified');
+		if ($status === 'true') {
+			$status = true;
+		} elseif ($status === 'false') {
+			$status = false;
+		} else {
+			throw new InvalidArgumentException(
+				"Argument value is not valid. Use true or false as argument value."
+			);
+		}
+
+		if ($input->getOption('all') !== false) {
+			$uids = 'all';
+		} else if(\count($input->getOption('uid'))) {
+			$uids = $input->getOption('uid');
+		} else {
+			throw new InvalidArgumentException(
+				"No user input specified. Use at least one --uid option to specify an user or --all option for all users."
+			);
+		}
+
+		$options = [
+			'uids' => $uids,
+			'status' => $status
+		];
+		return $options;
+	}
+}

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -25,12 +25,12 @@ namespace OCA\TwoFactor_Totp\Db;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Mapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDb;
+use OCP\IDBConnection;
 use OCP\IUser;
 
 class TotpSecretMapper extends Mapper {
 
-    public function __construct(IDb $db) {
+    public function __construct(IDBConnection $db) {
         parent::__construct($db, 'twofactor_totp_secrets');
     }
 
@@ -55,5 +55,16 @@ class TotpSecretMapper extends Mapper {
         }
         return TotpSecret::fromRow($row);
     }
+
+	/**
+	 * @param boolean $status
+	 */
+    public function setAllSecretsVerificationStatus($status) {
+		/* @var $qb IQueryBuilder */
+		$qb = $this->db->getQueryBuilder();
+		$qb->update('twofactor_totp_secrets')
+			->set('verified', $qb->createNamedParameter($status, IQueryBuilder::PARAM_BOOL))
+			->execute();
+	}
 
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -10,10 +10,10 @@
 	<!-- filters for code coverage -->
 	<filter>
 		<whitelist>
-			<directory suffix=".php">../mail</directory>
+			<directory suffix=".php">../../twofactor_totp</directory>
 			<exclude>
-				<directory suffix=".php">../twofactor_totp/l10n</directory>
-				<directory suffix=".php">../twofactor_totp/tests</directory>
+				<directory suffix=".php">../../twofactor_totp/l10n</directory>
+				<directory suffix=".php">../../twofactor_totp/tests</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/tests/unit/Command/SetSecretVerificationStatusCommandTest.php
+++ b/tests/unit/Command/SetSecretVerificationStatusCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Tests\Command;
+
+use OCP\IDBConnection;
+use Test\Traits\UserTrait;
+use OCA\TwoFactor_Totp\Command\SetSecretVerificationStatusCommand;
+use OCA\TwoFactor_Totp\Db\TotpSecret;
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class SetSecretVerificationStatusCommandTest
+ *
+ * @group DB
+ */
+class SetSecretVerificationStatusCommandTest extends TestCase {
+	use UserTrait;
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var string  */
+	private $dbTable = 'twofactor_totp_secrets';
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->db = \OC::$server->getDatabaseConnection();
+		$mapper = new TotpSecretMapper($this->db);
+		$command = new SetSecretVerificationStatusCommand($mapper, \OC::$server->getUserManager());
+		$this->commandTester = new CommandTester($command);
+
+		$this->createUser('user1');
+		$this->createUser('user2');
+		$mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user1',
+			'secret' => 'test',
+			'verified' => false
+		]));
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$query = $this->db->getQueryBuilder()->delete($this->dbTable);
+		$query->execute();
+	}
+
+	/**
+	 * @dataProvider inputProvider
+	 * @param array $input
+	 * @param string $expectedOutput
+	 */
+	public function testCommandInput($input, $expectedOutput) {
+		$this->commandTester->execute($input);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains($expectedOutput, $output);
+	}
+
+	public function inputProvider() {
+		return [
+			[
+				['set-verified' => 'true', '--uid' => ['user1']], 'The secret of user1 is verified'
+			],
+			[
+				['set-verified' => 'false', '--uid' => ['user1']], 'The secret of user1 is unverified'
+			],
+			[
+				['set-verified' => 'true',  '--uid' => ['user3']], 'User user3 does not exist'
+			],
+			[
+				['set-verified' => 'true', '-u' => ['user2']], 'User has no secret'
+			],
+			[
+				['set-verified' => 'true',  '--all' => ''], 'The status of all TOTP secrets has been set to verified'
+			],
+			[
+				['set-verified' => 'false', '--all' => ''], 'The status of all TOTP secrets has been set to unverified'
+			],
+			[
+				['set-verified' => 'false'], 'No user input specified.'
+			],
+			[
+				['set-verified' => 'error'], 'Argument value is not valid.'
+			],
+		];
+	}
+
+}

--- a/tests/unit/Db/TotpSecretMapperTest.php
+++ b/tests/unit/Db/TotpSecretMapperTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Twofactor_Totp\Tests\Db;
+
+
+use OCA\TwoFactor_Totp\Db\TotpSecret;
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use OCP\IDBConnection;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * @group DB
+ */
+class TotpSecretMapperTest extends TestCase {
+	use UserTrait;
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var TotpSecretMapper */
+	private $mapper;
+
+	/** @var string  */
+	private $dbTable = 'twofactor_totp_secrets';
+
+	protected function setUp() {
+		parent::setUp();
+		$this->db = \OC::$server->getDatabaseConnection();
+		$this->mapper = new TotpSecretMapper($this->db);
+		$this->createUser('user1');
+		$this->createUser('user2');
+		$this->mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user1',
+			'secret' => 'test',
+			'verified' => false
+		]));
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$query = $this->db->getQueryBuilder()->delete($this->dbTable);
+		$query->execute();
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\Db\DoesNotExistException
+	 */
+	public function testGetNonExistSecret() {
+		$user = \OC::$server->getUserManager()->get('user2');
+		$this->mapper->getSecret($user);
+	}
+
+	public function testGetSecret() {
+		$user = \OC::$server->getUserManager()->get('user1');
+		$secret = $this->mapper->getSecret($user);
+		$this->assertEquals($user->getUID(), $secret->getUserId());
+	}
+
+	public function testSetAllSecretsVerificationStatus() {
+		$this->mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user2',
+			'secret' => 'test',
+			'verified' => false
+		]));
+		$user1 = \OC::$server->getUserManager()->get('user1');
+		$user2 = \OC::$server->getUserManager()->get('user2');
+		$secret1 = $this->mapper->getSecret($user1);
+		$this->assertEquals(false, (boolean)$secret1->getVerified());
+		$secret2 = $this->mapper->getSecret($user2);
+		$this->assertEquals(false, (boolean)$secret2->getVerified());
+
+		$this->mapper->setAllSecretsVerificationStatus(true);
+		$secret1 = $this->mapper->getSecret($user1);
+		$this->assertEquals(true, (boolean)$secret1->getVerified());
+		$secret2 = $this->mapper->getSecret($user2);
+		$this->assertEquals(true, (boolean)$secret2->getVerified());
+
+		$this->mapper->setAllSecretsVerificationStatus(false);
+		$secret1 = $this->mapper->getSecret($user1);
+		$this->assertEquals(false, (boolean)$secret1->getVerified());
+		$secret2 = $this->mapper->getSecret($user2);
+		$this->assertEquals(false, (boolean)$secret2->getVerified());
+
+	}
+}


### PR DESCRIPTION
resolves #46,

I thought the creation date was stored, but there is no timestamps column in the database.  @PVince81 based on your idea, I added verifysecret and unverifysecret commands without timestamp.