### PR TITLE
listen user.afterdelete event to clear deleted user secrets

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -20,7 +20,9 @@
  */
 
 use OCA\TwoFactor_Totp\AppInfo\Application;
+use OCA\TwoFactor_Totp\Hooks;
 
 include_once __DIR__ . '/../vendor/autoload.php';
 
 $app = new Application();
+$app->getContainer()->query(Hooks::class)->register();

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ This extension provides the most simple way to add a second factor to user login
 	</commands>
 
 	<dependencies>
-		<owncloud min-version="10" max-version="10" />
+		<owncloud min-version="10.0.5" max-version="10" />
 		<php min-version="5.6" max-version="7.2" />
 	</dependencies>
 </info>

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -65,4 +65,14 @@ class TotpSecretMapper extends Mapper {
 			->set('verified', $qb->createNamedParameter($status, IQueryBuilder::PARAM_BOOL))
 			->execute();
 	}
+
+	/**
+	 * @param string $uid
+	 */
+	public function deleteSecretsByUserId($uid) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete('twofactor_totp_secrets')
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
+			->execute();
+	}
 }

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp;
+
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Class Hooks
+ *
+ * @package OCA\TwoFactor_Totp
+ */
+class Hooks {
+
+	/**
+	 * @var EventDispatcherInterface $eventDispatcher
+	 */
+	private $eventDispatcher;
+
+	/**
+	 * @var TotpSecretMapper $secretMapper
+	 */
+	private $secretMapper;
+
+	/**
+	 * Hooks constructor.
+	 *
+	 * @param EventDispatcherInterface $dispatcher
+	 * @param TotpSecretMapper $secretMapper
+	 */
+	public function __construct(EventDispatcherInterface $dispatcher, TotpSecretMapper $secretMapper) {
+		$this->eventDispatcher = $dispatcher;
+		$this->secretMapper = $secretMapper;
+	}
+
+	public function register() {
+		$this->eventDispatcher->addListener(
+			'user.afterdelete',
+			function (GenericEvent $event) {
+				$this->afterDeleteUser($event->getArgument('uid'));
+			}
+		);
+	}
+
+	/**
+	 * @param string $uid
+	 */
+	public function afterDeleteUser($uid) {
+		$this->secretMapper->deleteSecretsByUserId($uid);
+	}
+}

--- a/tests/unit/Db/TotpSecretMapperTest.php
+++ b/tests/unit/Db/TotpSecretMapperTest.php
@@ -99,4 +99,16 @@ class TotpSecretMapperTest extends TestCase {
 		$secret2 = $this->mapper->getSecret($user2);
 		$this->assertEquals(false, (boolean)$secret2->getVerified());
 	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\Db\DoesNotExistException
+	 */
+	public function testDeleteSecretsByUserId() {
+		$user = \OC::$server->getUserManager()->get('user1');
+		$secret = $this->mapper->getSecret($user);
+		$this->assertEquals($user->getUID(), $secret->getUserId());
+
+		$this->mapper->deleteSecretsByUserId('user1');
+		$this->mapper->getSecret($user);
+	}
 }

--- a/tests/unit/HooksTest.php
+++ b/tests/unit/HooksTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Twofactor_Totp\Tests;
+
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use OCA\Twofactor_Totp\Hooks;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Test\TestCase;
+
+/**
+ * Class HooksTest
+ *
+ * @package OCA\Twofactor_Totp\Tests
+ */
+class HooksTest extends TestCase {
+
+	/**
+	 * @var Hooks $hooks
+	 */
+	private $hooks;
+
+	/**
+	 * @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject $eventDispatcherMock
+	 */
+	private $eventDispatcherMock;
+
+	/**
+	 * @var TotpSecretMapper | \PHPUnit_Framework_MockObject_MockObject $secretMapperMock
+	 */
+	private $secretMapperMock;
+
+	public function setUp() {
+		parent::setUp();
+		$this->eventDispatcherMock = $this->getMockBuilder(EventDispatcherInterface::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->secretMapperMock = $this->getMockBuilder(TotpSecretMapper::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->hooks = new Hooks($this->eventDispatcherMock, $this->secretMapperMock);
+	}
+
+	public function testRegister() {
+		$this->eventDispatcherMock->expects($this->exactly(1))
+			->method('addListener');
+		$this->hooks->register();
+	}
+
+	public function testAfterDeleteUser() {
+		$this->secretMapperMock->expects($this->exactly(1))
+			->method('deleteSecretsByUserId')
+			->with('user1');
+		$this->hooks->afterDeleteUser('user1');
+	}
+}


### PR DESCRIPTION
closes #89 

By listening `user.afterdelete` event, deleted user secrets cleaned.

I added unit tests, also tested issue scenario manually.
