### PR TITLE
Fix composer install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ clean: ## Clean build
 install-deps: install-composer-deps
 
 install-composer-deps:
-	php composer install
+	composer install
 
 update-composer:
 	rm -f composer.lock
-	php composer install --prefer-dist
+	composer install --prefer-dist
 
 dist: clean install-deps
 	make clean
@@ -121,7 +121,7 @@ dist: clean install-deps
 	--exclude=.gitignore \
 	--exclude=.travis.yml \
 	--exclude=.scrutinizer.yml \
-        --exclude=CONTRIBUTING.md \
+	--exclude=CONTRIBUTING.md \
 	--exclude=composer.json \
 	--exclude=composer.lock \
 	--exclude=l10n/.tx \


### PR DESCRIPTION
When I ``make dist``:
```
make dist
rm -rf /home/phil/git/owncloud/core/apps-external/twofactor_totp/build/artifacts
rm -rf vendor
rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
php composer install
Could not open input file: composer
Makefile:108: recipe for target 'install-composer-deps' failed
make: *** [install-composer-deps] Error 1
```

Nowadays ``composer`` is assumed to be "somewhere" on the system. It is not sitting in the root dir of the git repo. So ``php composer`` does not work.
