### PR TITLE
exclude other new CI files from tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,15 @@ dist: clean install-deps
 	make install-composer-deps
 	mkdir -p $(sign_dir)
 	rsync -av \
+	--exclude=.drone.yml \
 	--exclude=.git \
-	--exclude=build \
 	--exclude=.gitignore \
+	--exclude=.phan \
+	--exclude=.php_cs.cache \
+	--exclude=.php_cs.dist \
 	--exclude=.travis.yml \
 	--exclude=.scrutinizer.yml \
+	--exclude=build \
 	--exclude=CONTRIBUTING.md \
 	--exclude=composer.json \
 	--exclude=composer.lock \
@@ -128,10 +132,13 @@ dist: clean install-deps
 	--exclude=l10n/no-php \
 	--exclude=Makefile \
 	--exclude=nbproject \
+	--exclude=phpcs.xml \
+	--exclude=phpstan.neon \
 	--exclude=phpunit*xml \
 	--exclude=screenshots \
 	--exclude=tests \
 	--exclude=vendor/bin \
+	--exclude=vendor-bin \
 	$(project_dir) $(sign_dir)
 ifdef CAN_SIGN
 	$(sign) --path="$(sign_dir)/$(app_name)"


### PR DESCRIPTION
This repo has a `Makefile` that includes everything in the dist tarball except for specifically-excluded things. That is the reverse logic to most of the other `make dist` scripts.

So we have to exclude all the new CI infrastructure files added in recent times.