### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -210,7 +210,7 @@ matrix:
   - PHP_VERSION: 7.2
     TEST_SUITE: owncloud-coding-standard
 
-  - PHP_VERSION: 5.6
+  - PHP_VERSION: 7.0
     TEST_SUITE: owncloud-coding-standard
 
   # Unit Tests master
@@ -258,13 +258,6 @@ matrix:
     COVERAGE: true
 
   # Unit Tests stable10
-  - PHP_VERSION: 5.6
-    OC_VERSION: daily-stable10-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-
   - PHP_VERSION: 7.0
     OC_VERSION: daily-stable10-qa
     TEST_SUITE: phpunit


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698