### PR TITLE
Add notify step to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -148,6 +148,15 @@ pipeline:
       matrix:
         COVERAGE: true
 
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [slack_webhook]
+    channel: builds
+    when:
+      status: [failure, changed]
+      event: [push, tag]
+
 services:
   mysql:
     image: mysql:5.5


### PR DESCRIPTION
I noticed that https://drone.owncloud.com/owncloud/twofactor_totp/202/80 failed last night but there was nothing reported in the build channel.

Add the missing `notify` step to drone.