### PR TITLE
Wait till verify msg is visible

### DIFF
--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -110,7 +110,7 @@ class TwoFactorTOTPContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theUserAddsVerficationKeyFromSecretKeyToVerifyUsingWebUI() {
+	public function theUserAddsVerificationKeyFromSecretKeyToVerifyUsingWebUI() {
 		if (!$this->totpUsed) {
 			$this->personalSecuritySettingsPage->addVerificationKey(
 				$this->generateTOTPKey()
@@ -130,7 +130,7 @@ class TwoFactorTOTPContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function totpSecretKeyShouldBeVerifiecOnTheWebUI() {
+	public function totpSecretKeyShouldBeVerifiedOnTheWebUI() {
 		Assert::assertTrue(
 			$this->personalSecuritySettingsPage->isKeyVerified(),
 			'The key could not be verified'

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
@@ -110,7 +110,7 @@ class PersonalSecuritySettingsPageWithTOTPEnabled extends PersonalSecuritySettin
 	 * @return bool
 	 */
 	public function isKeyVerified() {
-		$verificationMsg = $this->waitTillElementIsNotNull($this->totpVerifyMsgXpath);
+		$verificationMsg = $this->waitTillXpathIsVisible($this->totpVerifyMsgXpath);
 		$this->assertElementNotNull(
 			$verificationMsg,
 			__METHOD__ . ' The verification msg could not be found'

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
@@ -110,11 +110,11 @@ class PersonalSecuritySettingsPageWithTOTPEnabled extends PersonalSecuritySettin
 	 * @return bool
 	 */
 	public function isKeyVerified() {
-		$verificationMsg = $this->waitTillXpathIsVisible($this->totpVerifyMsgXpath);
-		$this->assertElementNotNull(
-			$verificationMsg,
-			__METHOD__ . ' The verification msg could not be found'
-		);
+		try {
+			$verificationMsg = $this->waitTillXpathIsVisible($this->totpVerifyMsgXpath);
+		} catch (\Exception $exception) {
+			return false;
+		}
 		return ($verificationMsg->getText() === 'Verified');
 	}
 }


### PR DESCRIPTION
Issue #117 
webUI acceptance test scenario `webUITwoFactorTOTP/keyVerification.feature:11` fails intermittently.
https://drone.owncloud.com/owncloud/twofactor_totp/210/112

The DOM element that has the "Verified" text can exist but not yet be visible. We need to wait until it is visible before trying to get the text.

Also fix a couple of minor typos in method names.