### PR TITLE
Add command for deleting redundant secrets

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,6 +24,7 @@ This extension provides the most simple way to add a second factor to user login
 	</settings>
 	<commands>
 		<command>OCA\TwoFactor_Totp\Command\SetSecretVerificationStatusCommand</command>
+		<command>OCA\TwoFactor_Totp\Command\DeleteRedundantSecretsCommand</command>
 	</commands>
 
 	<dependencies>

--- a/lib/Command/DeleteRedundantSecretsCommand.php
+++ b/lib/Command/DeleteRedundantSecretsCommand.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Sıla Boyraz <boyrazs15@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Command;
+
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteRedundantSecretsCommand extends Command {
+
+	/** @var TotpSecretMapper */
+	private $secretMapper;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(
+		TotpSecretMapper $secretMapper,
+		IUserManager $userManager
+	) {
+		parent::__construct();
+		$this->secretMapper = $secretMapper;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('twofactor_totp:delete-redundant-secret')
+			->setDescription(
+				'Delete the redundant secret of non-existing users'
+			);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$secrets = $this->secretMapper->getAllSecrets();
+		$count=0;
+		foreach ($secrets as $secret) {
+			$userId = $secret['user_id'];
+			if (!$this->userManager->userExists($userId)) {
+				$this->secretMapper->deleteSecretsByUserId($userId);
+				$output->writeln("<info>The redundant secret of $userId is deleted.</info>");
+				$count++;
+			}
+		}
+
+		$output->writeln("<info>$count redundant secrets are deleted</info>");
+		return 0;
+	}
+}

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -75,4 +75,12 @@ class TotpSecretMapper extends Mapper {
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
 			->execute();
 	}
+
+	public function getAllSecrets() {
+		$qb = $this->db->getQueryBuilder();
+		return $qb ->select('*')
+			->from('twofactor_totp_secrets')
+			->execute()
+			->fetchAll();
+	}
 }

--- a/tests/unit/Command/DeleteRedundantSecretsCommandTest.php
+++ b/tests/unit/Command/DeleteRedundantSecretsCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Sıla Boyraz <boyrazs15@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Tests\Command;
+
+use OCP\IDBConnection;
+use Test\Traits\UserTrait;
+use OCA\TwoFactor_Totp\Command\DeleteRedundantSecretsCommand;
+use OCA\TwoFactor_Totp\Db\TotpSecret;
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class DeleteRedundantSecretsCommandTest
+ *
+ * @group DB
+ */
+class DeleteRedundantSecretsCommandTest extends TestCase {
+	use UserTrait;
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var string  */
+	private $dbTable = 'twofactor_totp_secrets';
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->db = \OC::$server->getDatabaseConnection();
+		$mapper = new TotpSecretMapper($this->db);
+		$command = new DeleteRedundantSecretsCommand($mapper, \OC::$server->getUserManager());
+		$this->commandTester = new CommandTester($command);
+
+		$this->createUser('user1');
+		$mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user1',
+			'secret' => 'test',
+			'verified' => false
+		]));
+		$this->createUser('user2');
+		$mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user2',
+			'secret' => 'test',
+			'verified' => false
+		]));
+		$mapper->insert(TotpSecret::fromParams([
+			'userId' => 'nonexisting_user',
+			'secret' => 'test',
+			'verified' => false
+		]));
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$query = $this->db->getQueryBuilder()->delete($this->dbTable);
+		$query->execute();
+	}
+
+	public function testCommandInput() {
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains("The redundant secret of nonexisting_user is deleted.", $output);
+		$this->assertContains("1 redundant secrets are deleted", $output);
+	}
+}

--- a/tests/unit/Db/TotpSecretMapperTest.php
+++ b/tests/unit/Db/TotpSecretMapperTest.php
@@ -111,4 +111,16 @@ class TotpSecretMapperTest extends TestCase {
 		$this->mapper->deleteSecretsByUserId('user1');
 		$this->mapper->getSecret($user);
 	}
+
+	public function testGetAllSecrets() {
+		$secrets1 = $this->mapper->getAllSecrets();
+		$this->assertCount(1, $secrets1);
+		$this->mapper->insert(TotpSecret::fromParams([
+			'userId' => 'user3',
+			'secret' => 'test',
+			'verified' => false
+		]));
+		$secrets2 = $this->mapper->getAllSecrets();
+		$this->assertCount(2, $secrets2);
+	}
 }


### PR DESCRIPTION
Resolves #110

This PR adds a command for deleting non-existing users secret.