### PR TITLE
Initial drone starlark

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1,0 +1,1066 @@
+config = {
+	'app': 'twofactor_totp',
+	'rocketchat': {
+		'channel': 'builds',
+		'from_secret': 'private_rocketchat'
+	},
+
+	'branches': [
+		'master'
+	],
+
+	'appInstallCommand': 'make vendor',
+
+	'codestyle': {
+		'ordinary' : {
+			'phpVersions': [
+				'7.0',
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+		},
+	},
+
+	'javascript': False,
+
+	'phpunit': {
+		'allDatabasesExceptOracle' : {
+			'phpVersions': [
+				'7.0',
+			],
+			'databases': [
+				'sqlite',
+				'mariadb:10.2',
+				'mysql:5.5',
+				'mysql:5.7',
+				'postgres:9.4',
+			],
+		},
+		'reducedDatabases' : {
+			'phpVersions': [
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+			'databases': [
+				'mysql:5.5',
+			],
+			'coverage': False
+		},
+	},
+
+	'acceptance': {
+		'webUI': {
+			'suites': {
+				'webUITwoFactorTOTP': 'webUITwoFactTOTP',
+			},
+			'browsers': [
+				'chrome',
+				'firefox'
+			],
+		},
+		'api': {
+			'suites': [
+				'apiTwoFactorTOTP'
+			],
+		},
+		'cli': {
+			'suites': [
+				'cliTwoFactorTOTP'
+			],
+		},
+	},
+}
+
+def main(ctx):
+	before = beforePipelines()
+
+	stages = stagePipelines()
+	if (stages == False):
+		print('Errors detected. Review messages above.')
+		return []
+
+	dependsOn(before, stages)
+
+	after = afterPipelines()
+	dependsOn(stages, after)
+
+	return before + stages + after
+
+def beforePipelines():
+	return codestyle() + jscodestyle() + phpstan() + phan()
+
+def stagePipelines():
+	jsPipelines = javascript()
+	phpunitPipelines = phptests('phpunit')
+	phpintegrationPipelines = phptests('phpintegration')
+	acceptancePipelines = acceptance()
+	if (jsPipelines == False) or (phpunitPipelines == False) or (phpintegrationPipelines == False) or (acceptancePipelines == False):
+		return False
+
+	return jsPipelines + phpunitPipelines + phpintegrationPipelines + acceptancePipelines
+
+def afterPipelines():
+	return [
+		notify()
+	]
+
+def codestyle():
+	pipelines = []
+
+	if 'codestyle' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0'],
+	}
+
+	if 'defaults' in config:
+		if 'codestyle' in config['defaults']:
+			for item in config['defaults']['codestyle']:
+				default[item] = config['defaults']['codestyle'][item]
+
+	codestyleConfig = config['codestyle']
+
+	if type(codestyleConfig) == "bool":
+		if codestyleConfig:
+			# the config has 'codestyle' true, so specify an empty dict that will get the defaults
+			codestyleConfig = {}
+		else:
+			return pipelines
+
+	if len(codestyleConfig) == 0:
+		# 'codestyle' is an empty dict, so specify a single section that will get the defaults
+		codestyleConfig = {'doDefault': {}}
+
+	for category, matrix in codestyleConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'coding-standard-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					{
+						'name': 'coding-standard',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-style'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def jscodestyle():
+	pipelines = []
+
+	if 'jscodestyle' not in config:
+		return pipelines
+
+	if type(config['jscodestyle']) == "bool":
+		if not config['jscodestyle']:
+			return pipelines
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'coding-standard-js',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps': [
+			{
+				'name': 'coding-standard-js',
+				'image': 'owncloudci/php:7.2',
+				'pull': 'always',
+				'commands': [
+					'make test-js-style'
+				]
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	pipelines.append(result)
+
+	return pipelines
+
+def phpstan():
+	pipelines = []
+
+	if 'phpstan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.2'],
+		'logLevel': '2',
+	}
+
+	if 'defaults' in config:
+		if 'phpstan' in config['defaults']:
+			for item in config['defaults']['phpstan']:
+				default[item] = config['defaults']['phpstan'][item]
+
+	phpstanConfig = config['phpstan']
+
+	if type(phpstanConfig) == "bool":
+		if phpstanConfig:
+			# the config has 'phpstan' true, so specify an empty dict that will get the defaults
+			phpstanConfig = {}
+		else:
+			return pipelines
+
+	if len(phpstanConfig) == 0:
+		# 'phpstan' is an empty dict, so specify a single section that will get the defaults
+		phpstanConfig = {'doDefault': {}}
+
+	for category, matrix in phpstanConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'phpstan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					installCore('daily-master-qa', 'sqlite', False),
+					installApp(phpVersion),
+					setupServerAndApp(phpVersion, params['logLevel']),
+					{
+						'name': 'phpstan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phpstan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def phan():
+	pipelines = []
+
+	if 'phan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+	}
+
+	if 'defaults' in config:
+		if 'phan' in config['defaults']:
+			for item in config['defaults']['phan']:
+				default[item] = config['defaults']['phan'][item]
+
+	phanConfig = config['phan']
+
+	if type(phanConfig) == "bool":
+		if phanConfig:
+			# the config has 'phan' true, so specify an empty dict that will get the defaults
+			phanConfig = {}
+		else:
+			return pipelines
+
+	if len(phanConfig) == 0:
+		# 'phan' is an empty dict, so specify a single section that will get the defaults
+		phanConfig = {'doDefault': {}}
+
+	for category, matrix in phanConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'phan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					installCore('daily-master-qa', 'sqlite', False),
+					{
+						'name': 'phan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def javascript():
+	pipelines = []
+
+	if 'javascript' not in config:
+		return pipelines
+
+	default = {
+		'coverage': False,
+		'logLevel': '2',
+		'extraSetup': None,
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+	}
+
+	if 'defaults' in config:
+		if 'javascript' in config['defaults']:
+			for item in config['defaults']['javascript']:
+				default[item] = config['defaults']['javascript'][item]
+
+	matrix = config['javascript']
+
+	if type(matrix) == "bool":
+		if matrix:
+			# the config has 'javascript' true, so specify an empty dict that will get the defaults
+			matrix = {}
+		else:
+			return pipelines
+
+	params = {}
+	for item in default:
+		params[item] = matrix[item] if item in matrix else default[item]
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'javascript-tests',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps': [
+			installCore('daily-master-qa', 'sqlite', False),
+			installApp('7.0'),
+			setupServerAndApp('7.0', params['logLevel']),
+			params['extraSetup'],
+			{
+				'name': 'js-tests',
+				'image': 'owncloudci/php:7.0',
+				'pull': 'always',
+				'environment': params['extraEnvironment'],
+				'commands': params['extraCommandsBeforeTestRun'] + [
+					'make test-js'
+				]
+			}
+		],
+		'services': params['extraServices'],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	if params['coverage']:
+		result['steps'].append({
+			'name': 'codecov-js',
+			'image': 'plugins/codecov:2',
+			'pull': 'always',
+			'settings': {
+				'paths': [
+					'coverage/*.info',
+				],
+				'token': {
+					'from_secret': 'codecov_token'
+				}
+			}
+		})
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return [result]
+
+def phptests(testType):
+	pipelines = []
+
+	if testType not in config:
+		return pipelines
+
+	errorFound = False
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'databases': [
+			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+		],
+		'coverage': True,
+		'includeKeyInMatrixName': False,
+		'logLevel': '2',
+		'extraSetup': None,
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+		'extraApps': [],
+	}
+
+	if 'defaults' in config:
+		if testType in config['defaults']:
+			for item in config['defaults'][testType]:
+				default[item] = config['defaults'][testType][item]
+
+	phptestConfig = config[testType]
+
+	if type(phptestConfig) == "bool":
+		if phptestConfig:
+			# the config has just True, so specify an empty dict that will get the defaults
+			phptestConfig = {}
+		else:
+			return pipelines
+
+	if len(phptestConfig) == 0:
+		# the PHP test config is an empty dict, so specify a single section that will get the defaults
+		phptestConfig = {'doDefault': {}}
+
+	for category, matrix in phptestConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+
+			if testType == 'phpunit':
+				if params['coverage']:
+					command = 'make test-php-unit-dbg'
+				else:
+					command = 'make test-php-unit'
+			else:
+				if params['coverage']:
+					command = 'make test-php-integration-dbg'
+				else:
+					command = 'make test-php-integration'
+
+			for db in params['databases']:
+				keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+				name = '%s%s-php%s-%s' % (testType, keyString, phpVersion, db.replace(":", ""))
+				maxLength = 50
+				nameLength = len(name)
+				if nameLength > maxLength:
+					print("Error: generated phpunit stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+					errorFound = True
+
+				result = {
+					'kind': 'pipeline',
+					'type': 'docker',
+					'name': name,
+					'workspace' : {
+						'base': '/var/www/owncloud',
+						'path': 'server/apps/%s' % config['app']
+					},
+					'steps': [
+						installCore('daily-master-qa', db, False),
+						installApp(phpVersion),
+						installExtraApps(phpVersion, params['extraApps']),
+						setupServerAndApp(phpVersion, params['logLevel']),
+						params['extraSetup'],
+						{
+							'name': '%s-tests' % testType,
+							'image': 'owncloudci/php:%s' % phpVersion,
+							'pull': 'always',
+							'environment': params['extraEnvironment'],
+							'commands': params['extraCommandsBeforeTestRun'] + [
+								command
+							]
+						}
+					],
+					'services': databaseService(db) + params['extraServices'],
+					'depends_on': [],
+					'trigger': {
+						'ref': [
+							'refs/pull/**',
+							'refs/tags/**'
+						]
+					}
+				}
+
+				if params['coverage']:
+					result['steps'].append({
+						'name': 'codecov-upload',
+						'image': 'plugins/codecov:2',
+						'pull': 'always',
+						'settings': {
+							'paths': [
+								'tests/output/clover.xml',
+							],
+							'token': {
+								'from_secret': 'codecov_token'
+							}
+						}
+					})
+
+				for branch in config['branches']:
+					result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+				pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines
+
+def acceptance():
+	pipelines = []
+
+	if 'acceptance' not in config:
+		return pipelines
+
+	if type(config['acceptance']) == "bool":
+		if not config['acceptance']:
+			return pipelines
+
+	errorFound = False
+
+	default = {
+		'servers': ['daily-master-qa', 'latest'],
+		'browsers': ['chrome'],
+		'phpVersions': ['7.0'],
+		'databases': ['mariadb:10.2'],
+		'federatedServerNeeded': False,
+		'filterTags': '',
+		'logLevel': '2',
+		'emailNeeded': False,
+		'extraSetup': None,
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+		'extraApps': [],
+		'useBundledApp': False,
+		'includeKeyInMatrixName': False,
+	}
+
+	if 'defaults' in config:
+		if 'acceptance' in config['defaults']:
+			for item in config['defaults']['acceptance']:
+				default[item] = config['defaults']['acceptance'][item]
+
+	for category, matrix in config['acceptance'].items():
+		if type(matrix['suites']) == "list":
+			suites = {}
+			for suite in matrix['suites']:
+				suites[suite] = suite
+		else:
+			suites = matrix['suites']
+
+		for suite, shortSuiteName in suites.items():
+			isWebUI = suite.startswith('webUI')
+			isAPI = suite.startswith('api')
+			isCLI = suite.startswith('cli')
+
+			if isAPI or isCLI:
+				default['browsers'] = ['']
+
+			params = {}
+			for item in default:
+				params[item] = matrix[item] if item in matrix else default[item]
+
+			for server in params['servers']:
+				for browser in params['browsers']:
+					for phpVersion in params['phpVersions']:
+						for db in params['databases']:
+							name = 'unknown'
+
+							if isWebUI or isAPI or isCLI:
+								browserString = '' if browser == '' else '-' + browser
+								keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+								name = '%s%s-%s%s-%s-php%s' % (shortSuiteName, keyString, server.replace('daily-', '').replace('-qa', ''), browserString, db.replace(':', ''), phpVersion)
+								maxLength = 50
+								nameLength = len(name)
+								if nameLength > maxLength:
+									print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+									errorFound = True
+
+							environment = {}
+							for env in params['extraEnvironment']:
+								environment[env] = params['extraEnvironment'][env]
+
+							environment['TEST_SERVER_URL'] = 'http://server'
+							environment['BEHAT_FILTER_TAGS'] = params['filterTags']
+							environment['BEHAT_SUITE'] = suite
+
+							if isWebUI:
+								environment['SELENIUM_HOST'] = 'selenium'
+								environment['SELENIUM_PORT'] = '4444'
+								environment['BROWSER'] = browser
+								environment['PLATFORM'] = 'Linux'
+								makeParameter = 'test-acceptance-webui'
+
+							if isAPI:
+								makeParameter = 'test-acceptance-api'
+
+							if isCLI:
+								makeParameter = 'test-acceptance-cli'
+
+							if params['emailNeeded']:
+								environment['MAILHOG_HOST'] = 'email'
+
+							result = {
+								'kind': 'pipeline',
+								'type': 'docker',
+								'name': name,
+								'workspace' : {
+									'base': '/var/www/owncloud',
+									'path': 'testrunner/apps/%s' % config['app']
+								},
+								'steps': [
+									installCore(server, db, params['useBundledApp']),
+									installTestrunner(phpVersion, params['useBundledApp'])
+								] + ([
+									{
+										'name': 'install-federation',
+										'image': 'owncloudci/core',
+										'pull': 'always',
+										'settings': {
+											'version': server,
+											'core_path': '/var/www/owncloud/federated'
+										}
+									},
+									{
+										'name': 'configure-federation',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'commands': [
+											'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
+											'cd /var/www/owncloud/federated',
+											'php occ a:l',
+											'php occ a:e testing',
+											'php occ a:l',
+											'php occ config:system:set trusted_domains 1 --value=federated',
+											'php occ log:manage --level %s' % params['logLevel'],
+											'php occ config:list'
+										]
+									},
+									owncloudLog('federated')
+								] if params['federatedServerNeeded'] else []) + [
+									installApp(phpVersion),
+									installExtraApps(phpVersion, params['extraApps']),
+									setupServerAndApp(phpVersion, params['logLevel']),
+									owncloudLog('server'),
+									params['extraSetup'],
+									fixPermissions(phpVersion, params['federatedServerNeeded']),
+									({
+										'name': 'acceptance-tests',
+										'image': 'owncloudci/php:%s' % phpVersion,
+										'pull': 'always',
+										'environment': environment,
+										'commands': params['extraCommandsBeforeTestRun'] + [
+											'touch /var/www/owncloud/saved-settings.sh',
+											'. /var/www/owncloud/saved-settings.sh',
+											'make %s' % makeParameter
+										]
+									}),
+								],
+								'services': databaseService(db)
+									+ browserService(browser)
+									+ emailService(params['emailNeeded'])
+									+ params['extraServices']
+									+ owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False)
+									+ (owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if params['federatedServerNeeded'] else []),
+								'depends_on': [],
+								'trigger': {
+									'ref': [
+										'refs/pull/**',
+										'refs/tags/**'
+									]
+								}
+							}
+
+							for branch in config['branches']:
+								result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+							pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines
+
+def notify():
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'chat-notifications',
+		'clone': {
+			'disable': True
+		},
+		'steps': [
+			{
+				'name': 'notify-rocketchat',
+				'image': 'plugins/slack:1',
+				'pull': 'always',
+				'settings': {
+					'webhook': {
+						'from_secret': config['rocketchat']['from_secret']
+					},
+					'channel': config['rocketchat']['channel']
+				}
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return result
+
+def databaseService(db):
+	dbName = getDbName(db)
+	if (dbName == 'mariadb') or (dbName == 'mysql'):
+		return [{
+			'name': dbName,
+			'image': db,
+			'pull': 'always',
+			'environment': {
+				'MYSQL_USER': getDbUsername(db),
+				'MYSQL_PASSWORD': getDbPassword(db),
+				'MYSQL_DATABASE': getDbDatabase(db),
+				'MYSQL_ROOT_PASSWORD': getDbRootPassword()
+			}
+		}]
+
+	if dbName == 'postgres':
+		return [{
+			'name': dbName,
+			'image': db,
+			'pull': 'always',
+			'environment': {
+				'POSTGRES_USER': getDbUsername(db),
+				'POSTGRES_PASSWORD': getDbPassword(db),
+				'POSTGRES_DB': getDbDatabase(db)
+			}
+		}]
+
+	if dbName == 'oracle':
+		return [{
+			'name': dbName,
+			'image': 'deepdiver/docker-oracle-xe-11g:latest',
+			'pull': 'always',
+			'environment': {
+				'ORACLE_USER': getDbUsername(db),
+				'ORACLE_PASSWORD': getDbPassword(db),
+				'ORACLE_DB': getDbDatabase(db),
+				'ORACLE_DISABLE_ASYNCH_IO': 'true',
+			}
+		}]
+
+	return []
+
+def browserService(name):
+	if name == 'chrome':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-chrome-debug:3.141.59-oxygen',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING'
+			}
+		}]
+
+	if name == 'firefox':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-firefox-debug:3.8.1',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING',
+				'SE_OPTS': '-enablePassThrough false'
+			}
+		}]
+
+	return []
+
+def emailService(emailNeeded):
+	if emailNeeded:
+		return [{
+			'name': 'email',
+			'image': 'mailhog/mailhog',
+			'pull': 'always',
+		}]
+
+	return []
+
+def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncloud/server', ssl = True):
+	if ssl:
+		environment = {
+			'APACHE_WEBROOT': path,
+			'APACHE_CONFIG_TEMPLATE': 'ssl',
+			'APACHE_SSL_CERT_CN': 'server',
+			'APACHE_SSL_CERT': '/var/www/owncloud/%s.crt' % name,
+			'APACHE_SSL_KEY': '/var/www/owncloud/%s.key' % name
+		}
+	else:
+		environment = {
+			'APACHE_WEBROOT': path
+		}
+
+	return [{
+		'name': name,
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': environment,
+		'command': [
+			'/usr/local/bin/apachectl',
+			'-e',
+			'debug',
+			'-D',
+			'FOREGROUND'
+		]
+	}]
+
+def getDbName(db):
+	return db.split(':')[0]
+
+def getDbUsername(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'system'
+
+	return 'owncloud'
+
+def getDbPassword(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'oracle'
+
+	return 'owncloud'
+
+def getDbRootPassword():
+	return 'owncloud'
+
+def getDbDatabase(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'XE'
+
+	return 'owncloud'
+
+def installCore(version, db, useBundledApp):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db)
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+
+	if host == 'postgres':
+		dbType = 'pgsql'
+
+	if host == 'oracle':
+		dbType = 'oci'
+
+	stepDefinition = {
+		'name': 'install-core',
+		'image': 'owncloudci/core',
+		'pull': 'always',
+		'settings': {
+			'version': version,
+			'core_path': '/var/www/owncloud/server',
+			'db_type': dbType,
+			'db_name': database,
+			'db_host': host,
+			'db_username': username,
+			'db_password': password
+		}
+	}
+
+	if not useBundledApp:
+		stepDefinition['settings']['exclude'] = 'apps/%s' % config['app']
+
+	return stepDefinition
+
+def installTestrunner(phpVersion, useBundledApp):
+	return {
+		'name': 'install-testrunner',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'mkdir /tmp/testrunner',
+			'git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner',
+			'rsync -aIX /tmp/testrunner /var/www/owncloud',
+		] + ([
+			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
+		] if not useBundledApp else []) + [
+			'cd /var/www/owncloud/testrunner',
+			'make install-composer-deps vendor-bin-deps'
+		]
+	}
+
+def installExtraApps(phpVersion, extraApps):
+	if type(extraApps) == "list":
+		if extraApps == []:
+			return None
+		apps = {}
+		for app in extraApps:
+			apps[app] = None
+	else:
+		apps = {}
+		for app, command in extraApps.items():
+			apps[app] = command
+
+	commandArray = []
+	for app, command in apps.items():
+		commandArray.append('git clone https://github.com/owncloud/%s.git /var/www/owncloud/testrunner/apps/%s' % (app, app))
+		commandArray.append('cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % app)
+		if (command != None):
+			commandArray.append('cd /var/www/owncloud/server/apps/%s' % app)
+			commandArray.append(command)
+		commandArray.append('cd /var/www/owncloud/server')
+		commandArray.append('php occ a:l')
+		commandArray.append('php occ a:e %s' % app)
+		commandArray.append('php occ a:l')
+
+	return {
+		'name': 'install-extra-apps',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': commandArray
+	}
+
+def installApp(phpVersion):
+	if 'appInstallCommand' not in config:
+		return None
+
+	return {
+		'name': 'install-app-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'cd /var/www/owncloud/server/apps/%s' % config['app'],
+			config['appInstallCommand']
+		]
+	}
+
+def setupServerAndApp(phpVersion, logLevel):
+	return {
+		'name': 'setup-server-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'cd /var/www/owncloud/server',
+			'php occ a:l',
+			'php occ a:e %s' % config['app'],
+			'php occ a:e testing',
+			'php occ a:l',
+			'php occ config:system:set trusted_domains 1 --value=server',
+			'php occ log:manage --level %s' % logLevel,
+		]
+	}
+
+def fixPermissions(phpVersion, federatedServerNeeded):
+	return {
+		'name': 'fix-permissions',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'chown -R www-data /var/www/owncloud/server'
+		] + ([
+			'chown -R www-data /var/www/owncloud/federated'
+		] if federatedServerNeeded else [])
+	}
+
+def owncloudLog(server):
+	return {
+		'name': 'owncloud-log-%s' % server,
+		'image': 'owncloud/ubuntu:18.04',
+		'pull': 'always',
+		'detach': True,
+		'commands': [
+			'tail -f /var/www/owncloud/%s/data/owncloud.log' % server
+		]
+	}
+
+def dependsOn(earlierStages, nextStages):
+	for earlierStage in earlierStages:
+		for nextStage in nextStages:
+			nextStage['depends_on'].append(earlierStage['name'])

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -60,15 +60,12 @@ config = {
 				'firefox'
 			],
 		},
-		'api': {
-			'suites': [
-				'apiTwoFactorTOTP'
-			],
-		},
-		'cli': {
-			'suites': [
-				'cliTwoFactorTOTP'
-			],
+		# Note: the API and CLI tests need webUI steps for their setup, so they look like webUI suites
+		'webUIother': {
+			'suites': {
+				'webUIapiTwoFactorTOTP': 'webUIapiTOTP',
+				'webUIcliTwoFactorTOTP': 'webUIcliTOTP'
+			},
 		},
 	},
 }

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,380 +1,1737 @@
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
 workspace:
   base: /var/www/owncloud
-  path: apps/twofactor_totp
+  path: server/apps/twofactor_totp
 
-pipeline:
-  install-core:
-    image: owncloudci/core
-    pull: true
-    version: ${OC_VERSION}
-    db_type: ${DB_TYPE}
-    db_name: ${DB_NAME=owncloud}
-    db_host: ${DB_TYPE}
-    db_username: autotest
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-style
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-style
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-style
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-style
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-sqlite
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
     db_password: owncloud
-    when:
-      matrix:
-        NEED_CORE: true
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
 
-  install-testrunner:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
-    - cp -r /var/www/owncloud/apps/twofactor_totp /var/www/owncloud/testrunner/apps/
-    - cd /var/www/owncloud/testrunner
-    - make install-composer-deps
-    - make vendor-bin-deps
-    when:
-      matrix:
-        NEED_TARBALL: true
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
 
-  owncloud-log:
-    image: owncloud/ubuntu:16.04
-    detach: true
-    pull: true
-    commands:
-    - tail -f /var/www/owncloud/data/owncloud.log
-    when:
-      matrix:
-        NEED_SERVER: true
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
 
-  install-app:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - cd /var/www/owncloud/apps/twofactor_totp
-    - make vendor
-    - cd /var/www/owncloud/
-    - php occ a:l
-    - php occ a:e twofactor_totp
-    - php occ a:e testing
-    - php occ a:l
-    - php occ config:system:set trusted_domains 1 --value=owncloud
-    - php occ log:manage --level 0
-    when:
-      matrix:
-        NEED_INSTALL_APP: true
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
 
-  fix-permissions:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - chown www-data /var/www/owncloud -R
-    - if [ "${NEED_TARBALL}" = "true" ];
-      then chmod 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload -R;
-      chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh;
-      else chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R;
-      chmod +x /var/www/owncloud/tests/acceptance/run.sh; fi
-    when:
-      matrix:
-        NEED_SERVER: true
-
-  owncloud-coding-standard:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - make test-php-style
-    when:
-      matrix:
-        TEST_SUITE: owncloud-coding-standard
-
-  phpunit-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-    - COVERAGE=${COVERAGE}
-    commands:
-    - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
-    - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
-    when:
-      matrix:
-        TEST_SUITE: phpunit
-
-  api-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://owncloud
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - if [ "${NEED_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/twofactor_totp; fi
-      - make test-acceptance-api
-    when:
-      matrix:
-        TEST_SUITE: api-acceptance
-
-  cli-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://owncloud
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - if [ "${NEED_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/twofactor_totp; fi
-      - make test-acceptance-cli
-    when:
-      matrix:
-        TEST_SUITE: cli-acceptance
-
-  webui-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - BROWSER=chrome #chrome or firefox
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://owncloud
-      - PLATFORM=Linux
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - if [ "${NEED_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/twofactor_totp; fi
-      - make test-acceptance-webui
-    when:
-      matrix:
-        TEST_SUITE: web-acceptance
-
-  phan:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - make test-php-phan
-    when:
-      matrix:
-        TEST_SUITE: phan
-
-  phpstan:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-    - make test-php-phpstan
-    when:
-      matrix:
-        TEST_SUITE: phpstan
-
-  codecov:
-    image: plugins/codecov:2
-    secrets: [codecov_token]
-    pull: true
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
     paths:
     - tests/output/clover.xml
-    files:
-    - '*.xml'
-    when:
-      matrix:
-        COVERAGE: true
+    token:
+      from_secret: codecov_token
 
-  notify:
-    image: plugins/slack:1
-    pull: true
-    secrets: [slack_webhook]
-    channel: builds
-    when:
-      status: [failure, changed]
-      event: [push, tag]
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
 services:
-  mysql:
-    image: mysql:5.5
-    environment:
-    - MYSQL_USER=autotest
-    - MYSQL_PASSWORD=owncloud
-    - MYSQL_DATABASE=${DB_NAME=owncloud}
-    - MYSQL_ROOT_PASSWORD=owncloud
-    when:
-      matrix:
-        DB_TYPE: mysql
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
-  pgsql:
-    image: postgres:9.4
-    environment:
-    - POSTGRES_USER=autotest
-    - POSTGRES_PASSWORD=owncloud
-    - POSTGRES_DB=${DB_NAME=owncloud}
-    when:
-      matrix:
-        DB_TYPE: pgsql
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  oci:
-    image: deepdiver/docker-oracle-xe-11g
-    environment:
-    - ORACLE_USER=system
-    - ORACLE_PASSWORD=oracle
-    - ORACLE_DB=${DB_NAME=owncloud}
-    when:
-      matrix:
-        DB_TYPE: oci
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
 
-  owncloud:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-    - APACHE_WEBROOT=/var/www/owncloud/
-    command: ["/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND"]
-    when:
-      matrix:
-        NEED_SERVER: true
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.5
 
-  selenium:
-    image: selenium/standalone-chrome-debug:3.141.59-oxygen
-    pull: true
-    when:
-      matrix:
-        TEST_SUITE: web-acceptance
+platform:
+  os: linux
+  arch: amd64
 
-  email:
-    image: mailhog/mailhog
-    pull: true
-    when:
-      matrix:
-        USE_EMAIL: true
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
 
-matrix:
-  include:
-  # owncloud-coding-standard
-  - PHP_VERSION: 7.2
-    TEST_SUITE: owncloud-coding-standard
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
 
-  - PHP_VERSION: 7.0
-    TEST_SUITE: owncloud-coding-standard
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
 
-  # Unit Tests master
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
-  - PHP_VERSION: 7.3
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: sqlite
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.7
 
-  - PHP_VERSION: 7.3
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: mysql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+platform:
+  os: linux
+  arch: amd64
 
-  - PHP_VERSION: 7.0
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
 
-  - PHP_VERSION: 7.1
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
 
-  - PHP_VERSION: 7.2
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    COVERAGE: true
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
 
-  - PHP_VERSION: 7.3
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: phpunit
-    DB_TYPE: pgsql
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    COVERAGE: true
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
 
-  # Acceptance Tests
-  - PHP_VERSION: 7.1
-    DB_TYPE: mysql
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: web-acceptance
-    BEHAT_SUITE: cliTwoFactorTOTP
-    DB_NAME: oc_db
-    DB_USERNAME: admin
-    DB_PASSWORD: secret
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    NEED_SERVER: true
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
 
-  - PHP_VERSION: 7.1
-    DB_TYPE: mysql
-    OC_VERSION: daily-master-qa
-    TEST_SUITE: web-acceptance
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUITwoFactTOTP-master-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
     BEHAT_SUITE: webUITwoFactorTOTP
-    DB_NAME: oc_db
-    DB_USERNAME: admin
-    DB_PASSWORD: secret
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    NEED_SERVER: true
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
 
-  # Owncloud Tarball
-  - PHP_VERSION: 7.2
-    DB_TYPE: mysql
-    OC_VERSION: 10.2.1
-    TEST_SUITE: web-acceptance
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUITwoFactTOTP-master-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
     BEHAT_SUITE: webUITwoFactorTOTP
-    DB_NAME: oc_db
-    DB_USERNAME: admin
-    DB_PASSWORD: secret
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    NEED_SERVER: true
-    USE_EMAIL: true
-    NEED_TARBALL: true
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
 
-  - PHP_VERSION: 7.0
-    DB_TYPE: mysql
-    OC_VERSION: 10.2.1
-    TEST_SUITE: web-acceptance
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUITwoFactTOTP-latest-chrome-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUITwoFactorTOTP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUITwoFactTOTP-latest-firefox-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUITwoFactorTOTP
+    BROWSER: firefox
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-firefox-debug:3.8.1
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+    SE_OPTS: -enablePassThrough false
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiTwoFactorTOTP-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiTwoFactorTOTP
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiTwoFactorTOTP-latest-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiTwoFactorTOTP
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliTwoFactorTOTP-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
     BEHAT_SUITE: cliTwoFactorTOTP
-    DB_NAME: oc_db
-    DB_USERNAME: admin
-    DB_PASSWORD: secret
-    NEED_CORE: true
-    NEED_INSTALL_APP: true
-    NEED_SERVER: true
-    USE_EMAIL: true
-    NEED_TARBALL: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliTwoFactorTOTP-latest-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/twofactor_totp
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/twofactor_totp
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/twofactor_totp /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/twofactor_totp
+  - make vendor
+
+- name: setup-server-twofactor_totp
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e twofactor_totp
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliTwoFactorTOTP
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: chat-notifications
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  disable: true
+
+steps:
+- name: notify-rocketchat
+  pull: always
+  image: plugins/slack:1
+  settings:
+    channel: builds
+    webhook:
+      from_secret: private_rocketchat
+
+trigger:
+  ref:
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- phpunit-php7.0-sqlite
+- phpunit-php7.0-mariadb10.2
+- phpunit-php7.0-mysql5.5
+- phpunit-php7.0-mysql5.7
+- phpunit-php7.0-postgres9.4
+- phpunit-php7.1-mysql5.5
+- phpunit-php7.2-mysql5.5
+- phpunit-php7.3-mysql5.5
+- webUITwoFactTOTP-master-chrome-mariadb10.2-php7.0
+- webUITwoFactTOTP-master-firefox-mariadb10.2-php7.0
+- webUITwoFactTOTP-latest-chrome-mariadb10.2-php7.0
+- webUITwoFactTOTP-latest-firefox-mariadb10.2-php7.0
+- apiTwoFactorTOTP-master-mariadb10.2-php7.0
+- apiTwoFactorTOTP-latest-mariadb10.2-php7.0
+- cliTwoFactorTOTP-master-mariadb10.2-php7.0
+- cliTwoFactorTOTP-latest-mariadb10.2-php7.0
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1233,7 +1233,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiTwoFactorTOTP-master-mariadb10.2-php7.0
+name: webUIapiTOTP-master-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1306,9 +1306,13 @@ steps:
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-api
+  - make test-acceptance-webui
   environment:
-    BEHAT_SUITE: apiTwoFactorTOTP
+    BEHAT_SUITE: webUIapiTwoFactorTOTP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
     TEST_SERVER_URL: http://server
 
 services:
@@ -1320,6 +1324,12 @@ services:
     MYSQL_PASSWORD: owncloud
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
 
 - name: server
   pull: always
@@ -1348,7 +1358,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiTwoFactorTOTP-latest-mariadb10.2-php7.0
+name: webUIapiTOTP-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1421,9 +1431,13 @@ steps:
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-api
+  - make test-acceptance-webui
   environment:
-    BEHAT_SUITE: apiTwoFactorTOTP
+    BEHAT_SUITE: webUIapiTwoFactorTOTP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
     TEST_SERVER_URL: http://server
 
 services:
@@ -1435,6 +1449,12 @@ services:
     MYSQL_PASSWORD: owncloud
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
 
 - name: server
   pull: always
@@ -1463,7 +1483,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliTwoFactorTOTP-master-mariadb10.2-php7.0
+name: webUIcliTOTP-master-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1536,9 +1556,13 @@ steps:
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-cli
+  - make test-acceptance-webui
   environment:
-    BEHAT_SUITE: cliTwoFactorTOTP
+    BEHAT_SUITE: webUIcliTwoFactorTOTP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
     TEST_SERVER_URL: http://server
 
 services:
@@ -1550,6 +1574,12 @@ services:
     MYSQL_PASSWORD: owncloud
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
 
 - name: server
   pull: always
@@ -1578,7 +1608,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliTwoFactorTOTP-latest-mariadb10.2-php7.0
+name: webUIcliTOTP-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1651,9 +1681,13 @@ steps:
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-cli
+  - make test-acceptance-webui
   environment:
-    BEHAT_SUITE: cliTwoFactorTOTP
+    BEHAT_SUITE: webUIcliTwoFactorTOTP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
     TEST_SERVER_URL: http://server
 
 services:
@@ -1665,6 +1699,12 @@ services:
     MYSQL_PASSWORD: owncloud
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
 
 - name: server
   pull: always
@@ -1729,9 +1769,9 @@ depends_on:
 - webUITwoFactTOTP-master-firefox-mariadb10.2-php7.0
 - webUITwoFactTOTP-latest-chrome-mariadb10.2-php7.0
 - webUITwoFactTOTP-latest-firefox-mariadb10.2-php7.0
-- apiTwoFactorTOTP-master-mariadb10.2-php7.0
-- apiTwoFactorTOTP-latest-mariadb10.2-php7.0
-- cliTwoFactorTOTP-master-mariadb10.2-php7.0
-- cliTwoFactorTOTP-latest-mariadb10.2-php7.0
+- webUIapiTOTP-master-chrome-mariadb10.2-php7.0
+- webUIapiTOTP-latest-chrome-mariadb10.2-php7.0
+- webUIcliTOTP-master-chrome-mariadb10.2-php7.0
+- webUIcliTOTP-latest-chrome-mariadb10.2-php7.0
 
 ...

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -3,9 +3,9 @@ default:
     '': '%paths.base%/../features/bootstrap'
 
   suites:
-    cliTwoFactorTOTP:
+    webUIcliTwoFactorTOTP:
       paths:
-        - '%paths.base%/../features/cliTwoFactorTOTP'
+        - '%paths.base%/../features/webUIcliTwoFactorTOTP'
       contexts:
         - TwoFactorTOTPContext:
         - FeatureContext: &common_feature_context_params
@@ -30,9 +30,9 @@ default:
         - WebUIPersonalSecuritySettingsContext:
         - WebUILoginContext:
 
-    apiTwoFactorTOTP:
+    webUIapiTwoFactorTOTP:
       paths:
-        - '%paths.base%/../features/apiTwoFactorTOTP'
+        - '%paths.base%/../features/webUIapiTwoFactorTOTP'
       contexts:
         - TwoFactorTOTPContext:
         - FeatureContext: *common_feature_context_params

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -91,6 +91,7 @@ class TwoFactorTOTPContext implements Context {
 	 * Generate One time key for login from secret
 	 *
 	 * @return string
+	 * @throws Exception
 	 */
 	private function generateTOTPKey() {
 		$otp = new Otp();
@@ -177,6 +178,7 @@ class TwoFactorTOTPContext implements Context {
 	 * @param string $username
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theUserReLogsInAsForTwoFactorAuthentication($username) {
 		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
@@ -221,6 +223,7 @@ class TwoFactorTOTPContext implements Context {
 	 * @When the user adds one-time key generated from the secret key on the verification page on the webUI
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theUserAddsOneTimeKeyGeneratedOnVerificationPageOnTheWebui() {
 		$key = $this->generateTOTPKey();
@@ -252,7 +255,7 @@ class TwoFactorTOTPContext implements Context {
 	}
 
 	/**
-	 * Send request with secet key for two factor authentication
+	 * Send request with secret key for two factor authentication
 	 *
 	 * @param string $user
 	 * @param string $secretKey
@@ -278,6 +281,7 @@ class TwoFactorTOTPContext implements Context {
 	 * @param string $user
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function theAdministratorTriesToVerifyTheOtpKeyForUserUsingTheCorrectKey($user) {
 		$secretKey = $this->generateTOTPKey();

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -73,7 +73,7 @@ class VerificationPage extends OwncloudPage {
 
 	/**
 	 *
-	 * @return void
+	 * @return string
 	 */
 	public function getErrorMessage() {
 		$errorMessageElement = $this->find(

--- a/tests/acceptance/features/webUITwoFactorTOTP/keyVerification.feature
+++ b/tests/acceptance/features/webUITwoFactorTOTP/keyVerification.feature
@@ -1,8 +1,8 @@
 @webUI @insulated
-Feature: Testing Two factor TOTP
-  As a admin
-  I want to be able to verify secrets from webUI
-  So that the users can use two factor auth from TOTP key
+Feature: Use the webUI to verify OTP keys
+  As a user
+  I want to be able to use the webUI to activate and verify my OTP key
+  So that I can use two factor authentication
 
   Background:
     Given user "newly-created-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/webUIapiTwoFactorTOTP/keyVerificationByAPI.feature
+++ b/tests/acceptance/features/webUIapiTwoFactorTOTP/keyVerificationByAPI.feature
@@ -1,8 +1,10 @@
 @webUI
-Feature: Testing Two factor TOTP
-  As a admin
-  I want to send otp
-  So that I can check the result of last verification request
+Feature: Use an API to verify OTP keys for users
+  As an admin
+  I want to be able to use an API to verify OTP keys for users
+  So that I can remotely manage OTP for users
+
+  Note: this feature is testing the API, but needs webUI steps for scenario setup in "given" steps
 
   Background:
     Given these users have been created with default attributes and skeleton files:

--- a/tests/acceptance/features/webUIcliTwoFactorTOTP/keyVerificationByCLI.feature
+++ b/tests/acceptance/features/webUIcliTwoFactorTOTP/keyVerificationByCLI.feature
@@ -1,8 +1,10 @@
 @webUI
-Feature: Testing Two factor TOTP
-  As a admin
-  I want to be able to verify secrets
-  So that the users can use TOTP without verification with TOTP code
+Feature: Use the CLI to verify OTP keys for users
+  As an admin
+  I want to be able to use the CLI to verify OTP keys for users
+  So that I can manage OTP for users
+
+  Note: this feature is testing the CLI, but needs webUI steps for scenario setup in "given" steps
 
   Background:
     Given these users have been created with default attributes and skeleton files:


### PR DESCRIPTION
Notes: 
1) the previous `drone.yml` ran `webUITwoFactorTOTP` and `cliTwoFactorTOTP` acceptance test suites, but did not seem to run the `apiTwoFactorTOTP` acceptance test suite. That has been fixed here.
2) there were no tests with Oracle. When I tried to run PHP unit tests with Oracle, there were problems. See issue #140 
3) The `api` and `cli` acceptance test suites actually need to do webUI actions in their scenario setup `Given` steps. They really need to run `make test-acceptance-webui`. So I have renamed the suites so that they start with `webUI`. That makes all the processing by starlark, `Makefile` and... work in the "standard" way. (Previously the suites looked like API and CLI suites but has `@webUI` tag in the feature files, which was tricky and did not work nicely with the starlark script)