### PR TITLE
Fix casting problem

### DIFF
--- a/lib/Service/Totp.php
+++ b/lib/Service/Totp.php
@@ -119,7 +119,8 @@ class Totp implements ITotp {
 		 */
 		if ($dbSecret->getLastValidatedKey() !== $key) {
 			$secret = $this->crypto->decrypt($dbSecret->getSecret());
-			if ($this->otp->checkTotp(Base32::decode($secret), (int)$key, 3) === true) {
+			/* @phpstan-ignore-next-line */
+			if ($this->otp->checkTotp(Base32::decode($secret), $key, 3) === true) {
 				$dbSecret->setLastValidatedKey($key);
 				$this->secretMapper->update($dbSecret);
 				return true;

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -102,9 +102,9 @@ class TwoFactorTOTPContext implements Context {
 			$this->timeCounter += 1;
 		}
 		$this->counter += 1;
-		if ($this->counter > 3) {
+		if ($this->counter > 2) {
 			throw new \Exception(
-				'Key used more than three times'
+				'Key used more than twice'
 			);
 		}
 		return $otp->totp(Base32::decode($this->getSecret()), $this->timeCounter);
@@ -164,11 +164,6 @@ class TwoFactorTOTPContext implements Context {
 				$this->generateTOTPKey()
 			);
 			$this->totpUsed = true;
-			if ($this->personalSecuritySettingsPage->isKeyVerified() === false) {
-				$this->personalSecuritySettingsPage->addVerificationKey(
-					$this->generateTOTPKey()
-				);
-			}
 		} else {
 			throw new \Exception(
 				'TOTP Already used.' .
@@ -234,11 +229,6 @@ class TwoFactorTOTPContext implements Context {
 	public function theUserAddsOneTimeKeyGeneratedOnVerificationPageOnTheWebui() {
 		$key = $this->generateTOTPKey();
 		$this->verificationPage->addVerificationKey($key);
-		$response = $this->verificationPage->isErrorMessagePresent();
-		if ($response !== null) {
-			$key = $this->generateTOTPKey();
-			$this->verificationPage->addVerificationKey($key);
-		}
 	}
 
 	/**

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
@@ -34,7 +34,6 @@ class PersonalSecuritySettingsPageWithTOTPEnabled extends PersonalSecuritySettin
 	private $verificationFieldXpath = '//input[@id="totp-challenge"]';
 	private $totpVerifyMsgXpath = '//span[@id="totp-verify-msg"]';
 	private $verifySubmissionBtnXpath = '//button[@id="totp-verify-secret"]';
-	private $verifiedMsgXpath = '//span[@id="totp-verify-msg"][contains(text(), "Verified")]';
 
 	/**
 	 * Activate TOTP for the user
@@ -116,7 +115,6 @@ class PersonalSecuritySettingsPageWithTOTPEnabled extends PersonalSecuritySettin
 		} catch (\Exception $exception) {
 			return false;
 		}
-		$this->waitTillElementIsNotNull($this->verifiedMsgXpath);
 		return ($verificationMsg->getText() === 'Verified');
 	}
 }

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -22,7 +22,6 @@
 
 namespace Page;
 
-use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 
 /**
@@ -98,13 +97,5 @@ class VerificationPage extends OwncloudPage {
 		$this->waitTillElementIsNotNull($this->cancelOrLoginButtonXpath);
 		$cancel_btn = $this->find("xpath", $this->cancelOrLoginButtonXpath);
 		$cancel_btn->click();
-	}
-
-	/**
-	 *
-	 * @return NodeElement|null
-	 */
-	public function isErrorMessagePresent() {
-		return $this->find('xpath', $this->errorTokenMessageXpath);
 	}
 }


### PR DESCRIPTION
Fixes #170 
When the key starts with '0', typecasting to int operation loses that leading '0'. This problem has been fixed by removing the cast operation.

This situation discovered with random CI failures and we have added some retry scenarios. Since these scenarios no longer needed, the related commit has been reverted.