### PR TITLE
[tests-only] Do not run pipelines with encryption against old oC10

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -117,6 +117,9 @@ config = {
 					]
 				}
 			],
+			'servers': [
+				'daily-master-qa'
+			],
 			'phpVersions': [
 				'7.2',
 				'7.3'


### PR DESCRIPTION
Fixes #213 

The encryption app now only supports oC10.7 or later.