### PR TITLE
[Tests-Only] enforce strict type checking in acceptace tests code

### DIFF
--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPageWithTOTPEnabled.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * ownCloud
  *


### PR DESCRIPTION
Related https://github.com/owncloud/QA/issues/694
- add strict type checking on acceptace test code

**note** this PR was generated by a automated script