### PR TITLE
Align the code input field with the submit button on login

### DIFF
--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -3,7 +3,9 @@ script('core', 'login');
 ?>
 
 <form method="POST" name="login">
-    <input type="text" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off">
+	<div class="grouptop">
+		<input type="text" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off">
+	</div>
     <div class="submit-wrap">
         <button type="submit" id="submit" class="login-button">
             <span><?php p($l->t('Verify')); ?></span>

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -31,7 +31,7 @@ use Behat\Mink\Session;
  * @package Page
  */
 class VerificationPage extends OwncloudPage {
-	private $verificationFieldXpath = '//form/input[@name="challenge"]';
+	private $verificationFieldXpath = '//form//input[@name="challenge"]';
 	private $verifySubmissionBtnXpath = '//form//button[@type="submit"]';
 	private $errorTokenMessageXpath = '//div/span[contains(text(),"verifying the token")]';
 	private $cancelOrLoginButtonXpath = '//a[@class="two-factor-cancel"]';


### PR DESCRIPTION
... to match with the core login layout.

Related: https://github.com/owncloud/twofactor_totp/issues/237

Before:

![image](https://user-images.githubusercontent.com/50302941/145577804-7daf6d0b-41f2-47ac-b627-7be2be494727.png)


After:

![image](https://user-images.githubusercontent.com/50302941/145577769-d819e4a5-175f-4775-b538-094e03615402.png)
