### PR TITLE
[full-ci] remove php occ encryption:select-encryption-type from drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -91,7 +91,6 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
-                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },


### PR DESCRIPTION
Part of: https://github.com/owncloud/encryption/issues/393