### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/DeleteRedundantSecretsCommand.php
+++ b/lib/Command/DeleteRedundantSecretsCommand.php
@@ -57,9 +57,9 @@ class DeleteRedundantSecretsCommand extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$secrets = $this->secretMapper->getAllSecrets();
-		$count=0;
+		$count = 0;
 		foreach ($secrets as $secret) {
 			$userId = $secret['user_id'];
 			if (!$this->userManager->userExists($userId)) {

--- a/lib/Command/SetSecretVerificationStatusCommand.php
+++ b/lib/Command/SetSecretVerificationStatusCommand.php
@@ -77,7 +77,7 @@ class SetSecretVerificationStatusCommand extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$options = $this->parseInput($input);
 		} catch (InvalidArgumentException $e) {


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630