### PR TITLE
Fix problem with enforced 2fa and encryption

### DIFF
--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -83,6 +83,12 @@ class TotpProvider implements IProvider {
 	 * @return Template
 	 */
 	public function getTemplate(IUser $user) {
+		// If 2-factor is enforced, the challenge page will be accessed
+		// regardless of the user having configured the app or not.
+		// If the user doesn't have the app configured, we need to show
+		// the QR so the user is able to configured the app from the
+		// challenge page. The QR won't be shown if the app is already
+		// configured
 		$tmpl = new Template('twofactor_totp', 'challenge');
 		try {
 			$secretInfo = $this->totp->getSecretInfo($user);

--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -25,6 +25,7 @@ namespace OCA\TwoFactor_Totp\Provider;
 use OCA\TwoFactor_Totp\Service\ITotp;
 use OCA\TwoFactor_Totp\Service\OtpGen;
 use OCP\Authentication\TwoFactorAuth\IProvider;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\Template;
@@ -83,15 +84,17 @@ class TotpProvider implements IProvider {
 	 */
 	public function getTemplate(IUser $user) {
 		$tmpl = new Template('twofactor_totp', 'challenge');
-		if (!$this->isTwoFactorAuthEnabledForUser($user)) {
-			// If 2-factor is enforced, the challenge page will be accessed
-			// regardless of the user having configured the app or not.
-			// If the user doesn't have the app configured, we need to show
-			// the QR so the user is able to configured the app from the
-			// challenge page. The QR won't be shown if the app is already
-			// configured
-			$this->totp->deleteSecret($user);
+		try {
+			$secretInfo = $this->totp->getSecretInfo($user);
+			$secret = $secretInfo['secret'];
+			$verified = $secretInfo['verified'];
+		} catch (DoesNotExistException $ex) {
+			// create a new secret if the user doesn't have one
 			$secret = $this->totp->createSecret($user);
+			$verified = false;
+		}
+
+		if (!$verified) {
 			$tmpl->assign('isConfigured', false);
 			$tmpl->assign('qr', $this->otpGen->generateOtpQR($user, $secret));
 		} else {

--- a/lib/Service/ITotp.php
+++ b/lib/Service/ITotp.php
@@ -24,6 +24,7 @@ namespace OCA\TwoFactor_Totp\Service;
 
 use OCA\TwoFactor_Totp\Exception\NoTotpSecretFoundException;
 use OCA\TwoFactor_Totp\Exception\TotpSecretAlreadySet;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IUser;
 
 interface ITotp {
@@ -43,6 +44,17 @@ interface ITotp {
 	 * @param IUser $user
 	 */
 	public function deleteSecret(IUser $user);
+
+	/**
+	 * Get the information about the user's secret (if saved)
+	 * The information returned is an array with the following keys:
+	 * - 'secret' -> the secret saved
+	 * - 'verified' -> whether the secret has been verified by the client
+	 * @param IUser $user
+	 * @return array an array with the information explained above
+	 * @throws DoesNotExistException if there is no secret for the user
+	 */
+	public function getSecretInfo(IUser $user);
 
 	/**
 	 * @param IUser $user

--- a/lib/Service/Totp.php
+++ b/lib/Service/Totp.php
@@ -87,6 +87,17 @@ class Totp implements ITotp {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public function getSecretInfo(IUser $user) {
+		$totpSecret = $this->secretMapper->getSecret($user);
+		return [
+			'secret' => $this->crypto->decrypt($totpSecret->getSecret()),
+			'verified' => $totpSecret->getVerified(),
+		];
+	}
+
+	/**
 	 * @param IUser $user
 	 * @param string $key
 	 */


### PR DESCRIPTION
Ref: https://github.com/owncloud/enterprise/issues/6139

The problem was caused by an unexpected redirection which caused a second secret to be generated and stored, and it was different than the one shown in the QR.

The PR will only create new secrets if the user doesn't have one, otherwise it will show the same QR (if it hasn't been verified)