### PR TITLE
feat: allow occ admin to delete user's secrets

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,6 +26,7 @@ This extension provides the most simple way to add a second factor to user login
 	<commands>
 		<command>OCA\TwoFactor_Totp\Command\SetSecretVerificationStatusCommand</command>
 		<command>OCA\TwoFactor_Totp\Command\DeleteRedundantSecretsCommand</command>
+		<command>OCA\TwoFactor_Totp\Command\DeleteSecret</command>
 	</commands>
 
 	<dependencies>

--- a/lib/Command/DeleteSecret.php
+++ b/lib/Command/DeleteSecret.php
@@ -20,8 +20,6 @@
 namespace OCA\TwoFactor_Totp\Command;
 
 use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
-use OCP\IUserManager;
-use OCP\IUser;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,13 +30,9 @@ class DeleteSecret extends Command {
 	/** @var TotpSecretMapper */
 	private $secretMapper;
 
-	/** @var IUserManager */
-	private $userManager;
-
-	public function __construct(TotpSecretMapper $secretMapper, IUserManager $userManager) {
+	public function __construct(TotpSecretMapper $secretMapper) {
 		parent::__construct();
 		$this->secretMapper = $secretMapper;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure() {
@@ -65,12 +59,12 @@ class DeleteSecret extends Command {
 
 		if (!empty($uids)) {
 			foreach ($uids as $uid) {
-				$this->secretMapper->deleteSecretsByUserId($uid);
+				$secretCount = $this->secretMapper->deleteSecretsByUserId($uid);
+				$output->writeln("{$secretCount} secrets deleted for {$uid}");
 			}
 		} else {
-			$this->userManager->callForSeenUsers(function (IUser $user) {
-				$this->secretMapper->deleteSecretsByUserId($user->getUID());
-			});
+			$secretCount = $this->secretMapper->deleteAllSecrets();
+			$output->writeln("{$secretCount} secrets deleted");
 		}
 		return 0;
 	}

--- a/lib/Command/DeleteSecret.php
+++ b/lib/Command/DeleteSecret.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Command;
+
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use OCP\IUserManager;
+use OCP\IUser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteSecret extends Command {
+	/** @var TotpSecretMapper */
+	private $secretMapper;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(TotpSecretMapper $secretMapper, IUserManager $userManager) {
+		parent::__construct();
+		$this->secretMapper = $secretMapper;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this->setName('twofactor_totp:delete-secret')
+			->setDescription('Delete the secret of a user')
+			->addArgument(
+				'uids',
+				InputArgument::IS_ARRAY,
+				'The list of users whose secrets must be deleted'
+			)->addOption(
+				'all',
+				null,
+				InputOption::VALUE_NONE,
+				'Delete the secrets of all users'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$uids = $input->getArgument('uids');
+		if (empty($uids) && !$input->getOption('all')) {
+			$output->writeln('<error>Either --all or at least a user id must be provided</error>');
+			return 1;
+		}
+
+		if (!empty($uids)) {
+			foreach ($uids as $uid) {
+				$this->secretMapper->deleteSecretsByUserId($uid);
+			}
+		} else {
+			$this->userManager->callForSeenUsers(function (IUser $user) {
+				$this->secretMapper->deleteSecretsByUserId($user->getUID());
+			});
+		}
+		return 0;
+	}
+}

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -70,12 +70,23 @@ class TotpSecretMapper extends Mapper {
 
 	/**
 	 * @param string $uid
+	 * @return int the number of deleted secrets
 	 */
 	public function deleteSecretsByUserId($uid) {
 		$qb = $this->db->getQueryBuilder();
-		$qb->delete('twofactor_totp_secrets')
+		return $qb->delete('twofactor_totp_secrets')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
 			->execute();
+	}
+
+	/**
+	 * Remove all the secrets from all the users
+	 *
+	 * @return int the number of deleted secrets
+	 */
+	public function deleteAllSecrets() {
+		$qb = $this->db->getQueryBuilder();
+		return $qb->delete('twofactor_totp_secrets')->execute();
 	}
 
 	public function getAllSecrets() {

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -43,11 +43,6 @@ class TwoFactorTOTPContext implements Context {
 	private $personalSecuritySettingsPage;
 
 	/**
-	 * @var bool
-	 */
-	private $totpUsed = false;
-
-	/**
 	 * @var string|null
 	 */
 	private $totpSecret;
@@ -176,18 +171,9 @@ class TwoFactorTOTPContext implements Context {
 	 * @return void
 	 */
 	public function theUserAddsVerificationKeyFromSecretKeyToVerifyUsingWebUI(): void {
-		if (!$this->totpUsed) {
-			$this->personalSecuritySettingsPage->addVerificationKey(
-				$this->generateTOTPKey()
-			);
-			$this->totpUsed = true;
-		} else {
-			throw new \Exception(
-				'TOTP Already used.' .
-				'Key generation multiple times is not supported ' .
-				'due to the possibility of same key generation.'
-			);
-		}
+		$this->personalSecuritySettingsPage->addVerificationKey(
+			$this->generateTOTPKey()
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIcliTwoFactorTOTP/deleteSecret.feature
+++ b/tests/acceptance/features/webUIcliTwoFactorTOTP/deleteSecret.feature
@@ -1,0 +1,65 @@
+@webUI
+Feature: Use the CLI to delete secrets for users
+  As an admin
+  I want to be able to use the CLI to delete secrets for users
+  So that I can manage OTP for users
+
+  Note: this feature is testing the CLI, but needs webUI steps for scenario setup in "given" steps
+
+  Background:
+    Given these users have been created with default attributes and large skeleton files:
+      | username |
+      | Alice    |
+      | new-user |
+    And using OCS API version "2"
+
+  Scenario: Delete secret for a user having no secret
+    When the administrator invokes occ command "twofactor_totp:delete-secret new-user"
+    Then the command should have been successful
+    And the command output should contain the text "0 secrets deleted for new-user"
+    And user "new-user" should be able to access a skeleton file
+
+  Scenario: Delete secret for a user that has a secret
+    Given user "Alice" has logged in using the webUI
+    And the user has browsed to the personal security settings page
+    And the user has activated TOTP Second-factor auth but not verified
+    And the user adds one-time key generated from the secret key using the webUI
+    When the administrator invokes occ command "twofactor_totp:delete-secret Alice"
+    Then the command should have been successful
+    And the command output should contain the text "1 secrets deleted for Alice"
+    And user "Alice" using password "%regularuser%" should not be able to download file "textfile0.txt"
+
+  Scenario: Delete secrets for mutiple users
+    Given user "Alice" has logged in using the webUI
+    And the user has browsed to the personal security settings page
+    And the user has activated TOTP Second-factor auth but not verified
+    And the user adds one-time key generated from the secret key using the webUI
+    And the user logs out of the webUI
+    And user "new-user" has logged in using the webUI
+    And the user has browsed to the personal security settings page
+    And the user has activated TOTP Second-factor auth but not verified
+    And the user adds one-time key generated from the secret key using the webUI
+    And the user logs out of the webUI
+    When the administrator invokes occ command "twofactor_totp:delete-secret Alice new-user"
+    Then the command should have been successful
+    And the command output should contain the text "1 secrets deleted for Alice"
+    And the command output should contain the text "1 secrets deleted for new-user"
+    And user "Alice" using password "%regularuser%" should not be able to download file "textfile0.txt"
+    And user "new-user" using password "%regularuser%" should not be able to download file "textfile0.txt"
+
+  Scenario: Delete secrets for all users
+    Given user "Alice" has logged in using the webUI
+    And the user has browsed to the personal security settings page
+    And the user has activated TOTP Second-factor auth but not verified
+    And the user adds one-time key generated from the secret key using the webUI
+    And the user logs out of the webUI
+    And user "new-user" has logged in using the webUI
+    And the user has browsed to the personal security settings page
+    And the user has activated TOTP Second-factor auth but not verified
+    And the user adds one-time key generated from the secret key using the webUI
+    And the user logs out of the webUI
+    When the administrator invokes occ command "twofactor_totp:delete-secret --all"
+    Then the command should have been successful
+    And the command output should contain the text "2 secrets deleted"
+    And user "Alice" using password "%regularuser%" should not be able to download file "textfile0.txt"
+    And user "new-user" using password "%regularuser%" should not be able to download file "textfile0.txt"

--- a/tests/unit/Command/DeleteSecretTest.php
+++ b/tests/unit/Command/DeleteSecretTest.php
@@ -89,23 +89,8 @@ class DeleteSecretTest extends TestCase {
 	}
 
 	public function testCommandAllUsers() {
-		$user1 = $this->createMock(IUser::class);
-		$user1->method('getUID')->willReturn('user1');
-		$user2 = $this->createMock(IUser::class);
-		$user2->method('getUID')->willReturn('user2');
-		$user3 = $this->createMock(IUser::class);
-		$user3->method('getUID')->willReturn('user3');
-		$allUsers = [$user1, $user2, $user3];
-
-		$this->userManager->method('callForSeenUsers')
-			->will($this->returnCallback(function ($callback) use ($allUsers) {
-				foreach ($allUsers as $user) {
-					$callback($user);
-				}
-			}));
-
-		$this->mapper->expects($this->exactly(3))
-			->method('deleteSecretsByUserId');
+		$this->mapper->expects($this->once())
+			->method('deleteAllSecrets');
 
 		$this->commandTester->execute(['--all' => null]);
 		$this->assertSame(0, $this->commandTester->getStatusCode());

--- a/tests/unit/Command/DeleteSecretTest.php
+++ b/tests/unit/Command/DeleteSecretTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactor_Totp\Tests\Command;
+
+use OCP\IUser;
+use OCP\IUserManager;
+use OCA\TwoFactor_Totp\Command\DeleteSecret;
+use OCA\TwoFactor_Totp\Db\TotpSecretMapper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class DeleteRedundantSecretsCommandTest
+ */
+class DeleteSecretTest extends TestCase {
+	/** @var TotpSecretMapper */
+	private $mapper;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mapper = $this->createMock(TotpSecretMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$command = new DeleteSecret($this->mapper, $this->userManager);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testCommandNoParams() {
+		$this->commandTester->execute([]);
+		$this->assertSame(1, $this->commandTester->getStatusCode());
+	}
+
+	public function testCommandOneUser() {
+		$user1 = $this->createMock(IUser::class);
+		$user1->method('getUID')->willReturn('user1');
+
+		$this->userManager->method('get')
+			->will($this->returnValueMap([
+				['user1', $user1],
+			]));
+
+		$this->mapper->expects($this->once())
+			->method('deleteSecretsByUserId');
+
+		$this->commandTester->execute(['uids' => ['user1']]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+
+	public function testCommandMultipleUsers() {
+		$user1 = $this->createMock(IUser::class);
+		$user1->method('getUID')->willReturn('user1');
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')->willReturn('user2');
+
+		$this->userManager->method('get')
+			->will($this->returnValueMap([
+				['user1', $user1],
+				['user2', $user2],
+			]));
+
+		$this->mapper->expects($this->exactly(2))
+			->method('deleteSecretsByUserId');
+
+		$this->commandTester->execute(['uids' => ['user1', 'user2']]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+
+	public function testCommandAllUsers() {
+		$user1 = $this->createMock(IUser::class);
+		$user1->method('getUID')->willReturn('user1');
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')->willReturn('user2');
+		$user3 = $this->createMock(IUser::class);
+		$user3->method('getUID')->willReturn('user3');
+		$allUsers = [$user1, $user2, $user3];
+
+		$this->userManager->method('callForSeenUsers')
+			->will($this->returnCallback(function ($callback) use ($allUsers) {
+				foreach ($allUsers as $user) {
+					$callback($user);
+				}
+			}));
+
+		$this->mapper->expects($this->exactly(3))
+			->method('deleteSecretsByUserId');
+
+		$this->commandTester->execute(['--all' => null]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+}

--- a/tests/unit/Db/TotpSecretMapperTest.php
+++ b/tests/unit/Db/TotpSecretMapperTest.php
@@ -110,7 +110,7 @@ class TotpSecretMapperTest extends TestCase {
 		$secret = $this->mapper->getSecret($user);
 		$this->assertEquals($user->getUID(), $secret->getUserId());
 
-		$this->mapper->deleteSecretsByUserId('user1');
+		$this->assertSame(1, $this->mapper->deleteSecretsByUserId('user1'));
 		$this->mapper->getSecret($user);
 	}
 
@@ -124,5 +124,12 @@ class TotpSecretMapperTest extends TestCase {
 		]));
 		$secrets2 = $this->mapper->getAllSecrets();
 		$this->assertCount(2, $secrets2);
+	}
+
+	public function testDeleteAllSecrets() {
+		// only 1 existing secret in the DB, which will be deleted
+		$this->assertSame(1, $this->mapper->deleteAllSecrets());
+		// no secrets in the DB
+		$this->assertSame(0, $this->mapper->deleteAllSecrets());
 	}
 }


### PR DESCRIPTION
This allows admins to reset the secret in order to allow the user to login in case the user has lost the phone and he's locked out of his account.

Rel: https://github.com/owncloud/enterprise/issues/6252