### PR TITLE
Add `id="totp"` to TOTP input field for password manager auto-detection

### DIFF
--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -10,7 +10,7 @@ script('core', 'login');
 <?php endif; ?>
 <form method="POST" name="login">
 	<div class="grouptop">
-		<input type="text" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off">
+		<input id="totp" type="text" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off">
 	</div>
     <div class="submit-wrap">
         <button type="submit" id="submit" class="login-button">


### PR DESCRIPTION
This change adds an `id="totp"` attribute to the TOTP input field on the login page.

This helps password managers (such as Bitwarden, 1Password, and others) automatically detect and eventually fill the TOTP code field when using saved logins that include a 2FA token.

# Why

Without a clear identifier, most password managers fail to recognize the TOTP input automatically, forcing users to manually copy/paste the 2FA code.
This small change improves usability and accessibility for users who rely on password managers.

# Testing

- Verified that the TOTP field still works correctly for manual input.
- Confirmed that Bitwarden now correctly auto-fills the TOTP field when a matching entry is present.