### PR TITLE
chore(ci): move acceptance tests to GitHub workflows

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -60,22 +60,6 @@ config = {
     "javascript": False,
     "phpunit": False,
     "acceptance": {
-        "webUI": {
-            "suites": {
-                "webUITwoFactorTOTP": "webUITwoFactTOTP",
-            },
-            "browsers": [
-                "chrome",
-                "firefox",
-            ],
-        },
-        # Note: the API and CLI tests need webUI steps for their setup, so they look like webUI suites
-        "webUIother": {
-            "suites": {
-                "webUIapiTwoFactorTOTP": "webUIapiTOTP",
-                "webUIcliTwoFactorTOTP": "webUIcliTOTP",
-            },
-        },
         "webUI-encryption": {
             "suites": {
                 "webUIapiTwoFactorTOTP": "webUIapiTOTPEnc",
@@ -99,18 +83,6 @@ config = {
             "servers": [
                 "daily-master-qa",
             ],
-        },
-        "webUI-guests": {
-            "suites": [
-                "webUITOTPGuests",
-            ],
-            "extraApps": {
-                "guests": "",
-            },
-            "servers": [
-                "daily-master-qa",
-            ],
-            "emailNeeded": True,
         },
     },
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,24 @@ jobs:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
 
+  acceptance-webui:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+      test-suites: "['webUIapiTwoFactorTOTP', 'webUIcliTwoFactorTOTP', 'webUITwoFactorTOTP']"
+
+  acceptance-webui-guests:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+      use-email-server: true
+      additional-app: 'guests'
+      test-suites: "['webUITOTPGuests']"

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,11 @@ endif
 .PHONY: dist
 dist: $(dist_dir)/$(app_name)
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor
+	@echo dependencies and build actions for CI are completed
+
 #
 # Dependency management
 #--------------------------------------


### PR DESCRIPTION
This moves the ordinary acceptance tests to GitHub workflows.
Note: there are pipelines with encryption that will be moved in a later PR.