### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,123 @@
-# Two Factor Totp
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/twofactor_totp/status.svg?branch=master)](https://drone.owncloud.com/owncloud/twofactor_totp)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_twofactor_totp&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_twofactor_totp)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_twofactor_totp&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_twofactor_totp)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_twofactor_totp&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_twofactor_totp)
+# Two-Factor TOTP
 
-Tested with the following apps:
-* [OTP Authenticator](https://github.com/0xbb/otp-authenticator) (open source) which can be downloaded from [F-Droid](https://f-droid.org/repository/browse/?fdfilter=totp&fdid=net.bierbaumer.otp_authenticator) and has a built-in QR-code reader.
-* [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2) (proprietary)
-* [Twilio Authy](https://authy.com/) (proprietary)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-## Enabling TOTP 2FA for your account
-![](https://raw.githubusercontent.com/owncloud/twofactor_totp/stable9.1/screenshots/settings.png)
-![](https://raw.githubusercontent.com/owncloud/twofactor_totp/22056c405b5ebd39d2ed528291480d4c2959504b/screenshots/verify.jpg)
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](COPYING) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-## Running tests
-You can use the provided Makefile to run all tests by using:
+Two-Factor TOTP adds Time-based One-Time Password (TOTP) second-factor authentication to ownCloud Server. It is compatible with standard TOTP authenticator apps including Google Authenticator, Twilio Authy and the open-source OTP Authenticator from F-Droid, allowing users to secure their ownCloud accounts with a time-based code from their mobile device.
 
-    make test
+## Part of Classic (OC10)
 
-This will run the PHP unit and integration tests and if a package.json is present in the **js/** folder will execute **npm run test**
+This app is part of the [ownCloud Server (OC10)](https://github.com/owncloud/core) two-factor authentication ecosystem, providing TOTP-based second-factor login. It works alongside [twofactor_backup_codes](https://github.com/owncloud/twofactor_backup_codes) for account recovery.
 
-Of course you can also install [PHPUnit](http://phpunit.de/getting-started.html) and use the configurations directly:
+The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
 
-    phpunit -c phpunit.xml
+## Getting Started
 
-or:
+Follow the steps below to install and enable TOTP-based two-factor authentication.
 
-    phpunit -c phpunit.integration.xml
+### Installation
 
-for integration tests
+Install from the [ownCloud Marketplace](https://marketplace.owncloud.com/), or manually:
+
+```bash
+cd apps
+git clone https://github.com/owncloud/twofactor_totp.git
+cd ..
+php occ app:enable twofactor_totp
+```
+
+### Enabling TOTP
+
+Users enable TOTP in their personal settings by scanning the QR code displayed in the settings page with their authenticator app.
+
+### Running Tests
+
+```bash
+make test                  # Run all tests (PHP unit + JS if present)
+phpunit -c phpunit.xml     # Run PHP unit tests directly
+phpunit -c phpunit.integration.xml  # Run integration tests
+```
+
+## Documentation
+
+- [ownCloud Server Admin Manual](https://doc.owncloud.com/server/latest/admin_manual/)
+- [Two-Factor Authentication Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security_setup.html)
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/twofactor_totp)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](COPYING).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Two-Factor TOTP adds Time-based One-Time Password (TOTP) second-factor authentic
 
 ## Part of Classic (OC10)
 
-This app is part of the [ownCloud Server (OC10)](https://github.com/owncloud/core) two-factor authentication ecosystem, providing TOTP-based second-factor login. It works alongside [twofactor_backup_codes](https://github.com/owncloud/twofactor_backup_codes) for account recovery.
+This app is part of the [ownCloud Server (OC10)](https://github.com/owncloud/core) two-factor authentication ecosystem, providing TOTP-based second-factor login.
 
 The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,84 @@
+# agents.md — twofactor_totp
+
+## Repository Overview
+
+An ownCloud Server (OC10) app providing TOTP (Time-based One-Time Password) second-factor authentication. Compatible with Google Authenticator, Authy and other standard TOTP apps.
+
+- **Classification:** Classic (OC10)
+- **Activity Status:** Active
+- **License:** AGPL-3.0 (license file is `COPYING`)
+- **Language:** PHP
+
+## Architecture & Key Paths
+
+- `appinfo/` — ownCloud app metadata (info.xml, routes)
+- `lib/` — PHP backend (TOTP generation, verification, providers)
+- `js/` — Frontend JavaScript (QR code display, settings UI)
+- `l10n/` — Localization/translation files
+- `templates/` — PHP templates for settings UI
+- `screenshots/` — UI screenshots for documentation
+- `tests/` — PHPUnit unit and integration tests
+- `Makefile` — Build and test orchestration
+- `composer.json` — PHP dependencies
+- `phpcs.xml` — Code style configuration
+- `phpstan.neon` — Static analysis configuration
+- `phpunit.xml` — Unit test configuration
+- `COPYING` — AGPL-3.0 license file
+- `AUTHORS.md` — List of contributors
+
+## Development Conventions
+
+- Standard ownCloud OC10 app structure
+- Code style enforced by phpcs (`phpcs.xml`)
+- Static analysis via PHPStan
+- SonarCloud integration
+- License file is named `COPYING` (not `LICENSE`)
+
+## Build & Test Commands
+
+```bash
+make test                   # Run all tests
+make test-php-unit          # Run PHP unit tests
+make test-php-style         # Check code style (phpcs)
+make test-php-style-fix     # Auto-fix code style issues
+make test-php-phan          # Run Phan static analysis
+make test-php-phpstan       # Run PHPStan static analysis
+make dist                   # Build distribution package
+make clean                  # Clean build artifacts
+phpunit -c phpunit.xml      # Run unit tests directly
+phpunit -c phpunit.integration.xml  # Run integration tests
+```
+
+## Important Constraints
+
+- **AGPL-3.0 copyleft license:** This repository is AGPL-3.0. The OSPO Apache 2.0 migration requires auditing copyleft dependencies and contributor agreements before relicensing.
+- **Security-sensitive:** Handles TOTP secret generation and verification -- changes must be carefully reviewed.
+- **Companion app:** Works alongside `twofactor_backup_codes` for a complete 2FA solution with recovery.
+- **License file naming:** The license file is `COPYING`, not `LICENSE`.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+- This is an ownCloud Server (OC10) app, not an oCIS extension.
+- The `lib/` directory contains TOTP generation, secret storage and verification logic.
+- Users configure TOTP through their personal settings page.
+- QR code generation for authenticator app enrollment is handled in `js/`.
+- The `l10n/` directory provides translations.

--- a/agents.md
+++ b/agents.md
@@ -17,7 +17,7 @@ An ownCloud Server (OC10) app providing TOTP (Time-based One-Time Password) seco
 - `l10n/` — Localization/translation files
 - `templates/` — PHP templates for settings UI
 - `screenshots/` — UI screenshots for documentation
-- `tests/` — PHPUnit unit and integration tests
+- `tests/` — PHPUnit unit and acceptance tests
 - `Makefile` — Build and test orchestration
 - `composer.json` — PHP dependencies
 - `phpcs.xml` — Code style configuration
@@ -43,10 +43,10 @@ make test-php-style         # Check code style (phpcs)
 make test-php-style-fix     # Auto-fix code style issues
 make test-php-phan          # Run Phan static analysis
 make test-php-phpstan       # Run PHPStan static analysis
+make test-acceptance-webui  # Run WebUI acceptance tests
 make dist                   # Build distribution package
 make clean                  # Clean build artifacts
 phpunit -c phpunit.xml      # Run unit tests directly
-phpunit -c phpunit.integration.xml  # Run integration tests
 ```
 
 ## Important Constraints


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>