### PR TITLE
test: pass timeout_msec through to waitTillElementIsNotNull on VerificationPage

### DIFF
--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -262,7 +262,7 @@ class TwoFactorTOTPContext implements Context {
 	}
 
 	/**
-	 * Send request with secret key for two factor authentication
+	 * Send request with secret key for two-factor authentication
 	 *
 	 * @param string $user
 	 * @param string $secretKey

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -50,7 +50,10 @@ class VerificationPage extends OwncloudPage {
 		Session $session,
 		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	): void {
-		$field = $this->waitTillElementIsNotNull($this->verificationFieldXpath);
+		$field = $this->waitTillElementIsNotNull(
+			$this->verificationFieldXpath,
+			$timeout_msec
+		);
 		$this->assertElementNotNull(
 			$field,
 			__METHOD__ . ' Field for adding verification code could not be found'

--- a/tests/acceptance/features/webUIcliTwoFactorTOTP/deleteSecret.feature
+++ b/tests/acceptance/features/webUIcliTwoFactorTOTP/deleteSecret.feature
@@ -29,7 +29,7 @@ Feature: Use the CLI to delete secrets for users
     And the command output should contain the text "1 secrets deleted for Alice"
     And user "Alice" using password "%regularuser%" should not be able to download file "textfile0.txt"
 
-  Scenario: Delete secrets for mutiple users
+  Scenario: Delete secrets for multiple users
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the personal security settings page
     And the user has activated TOTP Second-factor auth but not verified


### PR DESCRIPTION
The timeout_msec parameter to waitTillPageIsLoaded was being ignored. Now it is passed on.

A few other minor grammar changes were also made.