### PR TITLE
fix: show the TOTP secret next to the QR code on the challenge page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - xxxx-xx-xx
 
+### Fixed
+- [#340](https://github.com/owncloud/twofactor_totp/pull/340) - fix: show the TOTP secret next to the QR code on the challenge page
+
+  When two-factor auth is enforced (`enforce_2fa`), a user who has never
+  configured TOTP is sent straight to the challenge page and cannot reach the
+  personal security settings. The challenge page offered only the QR code, so
+  users who are unable to scan one had no way to enrol. The secret is now shown
+  next to the QR code, as it already is in the personal settings. It is still
+  never shown to users who have verified a secret.
+
 
 ## [0.10.1] - 2026-07-22
 

--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -86,8 +86,9 @@ class TotpProvider implements IProvider {
 		// If 2-factor is enforced, the challenge page will be accessed
 		// regardless of the user having configured the app or not.
 		// If the user doesn't have the app configured, we need to show
-		// the QR so the user is able to configured the app from the
-		// challenge page. The QR won't be shown if the app is already
+		// the QR and the secret so the user is able to configured the app
+		// from the challenge page - the secret because not every user is
+		// able to scan a QR code. Neither is shown if the app is already
 		// configured
 		$tmpl = new Template('twofactor_totp', 'challenge');
 		try {
@@ -103,6 +104,7 @@ class TotpProvider implements IProvider {
 		if (!$verified) {
 			$tmpl->assign('isConfigured', false);
 			$tmpl->assign('qr', $this->otpGen->generateOtpQR($user, $secret));
+			$tmpl->assign('secret', $secret);
 		} else {
 			$tmpl->assign('isConfigured', true);
 		}

--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -86,7 +86,7 @@ class TotpProvider implements IProvider {
 		// If 2-factor is enforced, the challenge page will be accessed
 		// regardless of the user having configured the app or not.
 		// If the user doesn't have the app configured, we need to show
-		// the QR and the secret so the user is able to configured the app
+		// the QR and the secret so the user is able to configure the app
 		// from the challenge page - the secret because not every user is
 		// able to scan a QR code. Neither is shown if the app is already
 		// configured

--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -6,6 +6,7 @@ script('core', 'login');
 <div class="grouptop" style="align-items:center;">
 	<p class="info"><?php p($l->t('Scan the QR code below with your TOTP app and enter the code')); ?></p>
 	<img src="<?php p($_['qr']); ?>" />
+	<p class="info"><?php p($l->t('This is your new TOTP secret:')); ?> <strong><?php p($_['secret']); ?></strong></p>
 </div>
 <?php endif; ?>
 <form method="POST" name="login">

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -298,7 +298,6 @@ class TwoFactorTOTPContext implements Context {
 
 	/**
 	 * @When the user adds one-time key generated from the secret displayed on the verification page
-	 * @Given the user has added one-time key generated from the secret displayed on the verification page
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -443,5 +443,6 @@ class TwoFactorTOTPContext implements Context {
 	 */
 	public function resetEnforcedTwoFactorAuth(): void {
 		$this->occContext->deleteConfigKeyOfAppUsingTheOccCommand('enforce_2fa', 'core');
+		$this->occContext->deleteConfigKeyOfAppUsingTheOccCommand('enforce_2fa_excluded_groups', 'core');
 	}
 }

--- a/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
+++ b/tests/acceptance/features/bootstrap/TwoFactorTOTPContext.php
@@ -66,6 +66,12 @@ class TwoFactorTOTPContext implements Context {
 	private $verificationPage;
 
 	/**
+	 *
+	 * @var OccContext
+	 */
+	private $occContext;
+
+	/**
 	 * @var int
 	 */
 	private $counter;
@@ -142,8 +148,21 @@ class TwoFactorTOTPContext implements Context {
 	 * @return string
 	 */
 	public function getSecretCodeFromQRCode(): string {
+		return $this->extractSecretFromQRCode(
+			$this->personalSecuritySettingsPage->getQRCode()
+		);
+	}
+
+	/**
+	 * Returns the secret code encoded in the given base64 QR code image
+	 *
+	 * @param string $qrCodeImage the "src" attribute of the QR code image
+	 *
+	 * @return string
+	 */
+	private function extractSecretFromQRCode(string $qrCodeImage): string {
 		$path = \tempnam(\sys_get_temp_dir(), 'totp_qrcode');
-		$data = \explode(',', $this->personalSecuritySettingsPage->getQRCode());
+		$data = \explode(',', $qrCodeImage);
 		$file = \fopen($path, 'wb');
 		\fwrite($file, \base64_decode($data[1]));
 		$qrCode = new QrReader($path);
@@ -262,6 +281,46 @@ class TwoFactorTOTPContext implements Context {
 	}
 
 	/**
+	 * @Then the secret code from the QR code should match the one displayed on the verification page
+	 *
+	 * @return void
+	 */
+	public function theSecretCodeFromTheQRCodeShouldMatchTheOneDisplayedOnTheVerificationPage(): void {
+		$secretFromQRCode = $this->extractSecretFromQRCode(
+			$this->verificationPage->getEnrolmentQRCode()
+		);
+		Assert::assertEquals(
+			$secretFromQRCode,
+			$this->verificationPage->getEnrolmentSecret(),
+			'The secret displayed on the verification page does not match the one encoded in the QR code'
+		);
+	}
+
+	/**
+	 * @When the user adds one-time key generated from the secret displayed on the verification page
+	 * @Given the user has added one-time key generated from the secret displayed on the verification page
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserAddsOneTimeKeyGeneratedFromTheSecretOnTheVerificationPage(): void {
+		$this->totpSecret = $this->verificationPage->getEnrolmentSecret();
+		$this->verificationPage->addVerificationKey($this->generateTOTPKey());
+	}
+
+	/**
+	 * @Then the enrolment secret should not be displayed on the verification page
+	 *
+	 * @return void
+	 */
+	public function theEnrolmentSecretShouldNotBeDisplayedOnTheVerificationPage(): void {
+		Assert::assertNull(
+			$this->verificationPage->isEnrolmentBlockPresent(),
+			'The enrolment QR code and secret must not be shown to a user who has already configured TOTP'
+		);
+	}
+
+	/**
 	 * Send request with secret key for two-factor authentication
 	 *
 	 * @param string $user
@@ -369,5 +428,20 @@ class TwoFactorTOTPContext implements Context {
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
+		$this->occContext = $environment->getContext('OccContext');
+	}
+
+	/**
+	 * Enforcing 2-factor auth is not undone by the test framework, so it has to
+	 * be cleared here. Otherwise it would leak into the scenarios that run
+	 * afterwards and send them to the verification page on login.
+	 *
+	 * @AfterScenario @enforce-2fa
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function resetEnforcedTwoFactorAuth(): void {
+		$this->occContext->deleteConfigKeyOfAppUsingTheOccCommand('enforce_2fa', 'core');
 	}
 }

--- a/tests/acceptance/features/lib/VerificationPage.php
+++ b/tests/acceptance/features/lib/VerificationPage.php
@@ -35,6 +35,11 @@ class VerificationPage extends OwncloudPage {
 	private $verifySubmissionBtnXpath = '//form//button[@type="submit"]';
 	private $errorTokenMessageXpath = '//div/span[contains(text(),"verifying the token")]';
 	private $cancelOrLoginButtonXpath = '//a[@class="two-factor-cancel"]';
+	// the form input is wrapped in a "grouptop" div as well, so the enrolment
+	// block is identified by the QR code image it contains
+	private $enrolmentBlockXpath = '//div[contains(@class,"grouptop")][.//img]';
+	private $enrolmentQrCodeXpath = '//div[contains(@class,"grouptop")]//img';
+	private $enrolmentSecretXpath = '//div[contains(@class,"grouptop")]//p/strong';
 
 	/**
 	 * there is no reliable loading indicator on the verification page, so just wait for
@@ -109,5 +114,50 @@ class VerificationPage extends OwncloudPage {
 	 */
 	public function isErrorMessagePresent(): ?NodeElement {
 		return $this->find('xpath', $this->errorTokenMessageXpath);
+	}
+
+	/**
+	 * Returns the enrolment QR code image in base64.
+	 *
+	 * The QR code is only rendered when the user has not verified a secret yet,
+	 * which is the case when 2-factor auth is enforced for a user who has never
+	 * configured the app.
+	 *
+	 * @return string
+	 */
+	public function getEnrolmentQRCode(): string {
+		$image = $this->waitTillElementIsNotNull($this->enrolmentQrCodeXpath);
+		$this->assertElementNotNull(
+			$image,
+			__METHOD__ . ' enrolment QR code not found on the verification page'
+		);
+		return $image->getAttribute("src");
+	}
+
+	/**
+	 * Returns the enrolment block (QR code and secret), or null when the user
+	 * has already verified a secret and does not need to enrol.
+	 *
+	 * @return NodeElement|null
+	 */
+	public function isEnrolmentBlockPresent(): ?NodeElement {
+		return $this->find('xpath', $this->enrolmentBlockXpath);
+	}
+
+	/**
+	 * Returns the enrolment secret displayed next to the QR code.
+	 *
+	 * It is displayed for users who cannot scan a QR code and have to type the
+	 * secret into their TOTP app by hand.
+	 *
+	 * @return string
+	 */
+	public function getEnrolmentSecret(): string {
+		$secret = $this->waitTillElementIsNotNull($this->enrolmentSecretXpath);
+		$this->assertElementNotNull(
+			$secret,
+			__METHOD__ . ' enrolment secret not found on the verification page'
+		);
+		return \trim($secret->getText());
 	}
 }

--- a/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
+++ b/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
@@ -1,0 +1,34 @@
+@webUI @insulated @enforce-2fa
+Feature: Enrol a TOTP app from the verification page when two-factor auth is enforced
+  As a user who has never configured TOTP
+  I want to be shown both the QR code and the secret on the verification page
+  So that I can enrol my TOTP app even if I am not able to scan a QR code
+
+  When two-factor auth is enforced, a user who has not configured TOTP yet is
+  sent straight to the verification page and cannot reach the personal security
+  settings page. The verification page is therefore the only place where such a
+  user can enrol, and it has to offer the secret in text form as well - not
+  every user is able to scan a QR code.
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And using OCS API version "2"
+    And the administrator has added config key "enforce_2fa" with value "yes" in app "core"
+
+
+  Scenario: The QR code and the secret are both shown on the verification page
+    When user "Alice" logs in using the webUI after a redirect from the "VerificationPage" page
+    Then the secret code from the QR code should match the one displayed on the verification page
+
+
+  Scenario: A user who cannot scan the QR code can enrol using the displayed secret
+    Given user "Alice" has logged in using the webUI after a redirect from the "VerificationPage" page
+    When the user adds one-time key generated from the secret displayed on the verification page
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+
+  Scenario: The secret is no longer disclosed once the user has enrolled
+    Given user "Alice" has logged in using the webUI after a redirect from the "VerificationPage" page
+    And the user has added one-time key generated from the secret displayed on the verification page
+    When the user re-logs in as "Alice" to the two-factor authentication verification page
+    Then the enrolment secret should not be displayed on the verification page

--- a/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
+++ b/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
@@ -27,13 +27,14 @@ Feature: Enrol a TOTP app from the verification page when two-factor auth is enf
 
 
   Scenario: A user who cannot scan the QR code can enrol using the displayed secret
-    Given user "Alice" has logged in using the webUI after a redirect from the "verification" page
-    When the user adds one-time key generated from the secret displayed on the verification page
+    When user "Alice" logs in using the webUI after a redirect from the "verification" page
+    And the user adds one-time key generated from the secret displayed on the verification page
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
 
   Scenario: The secret is no longer disclosed once the user has enrolled
-    Given user "Alice" has logged in using the webUI after a redirect from the "verification" page
-    And the user has added one-time key generated from the secret displayed on the verification page
+    When user "Alice" logs in using the webUI after a redirect from the "verification" page
+    And the user adds one-time key generated from the secret displayed on the verification page
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
     When the user re-logs in as "Alice" to the two-factor authentication verification page
     Then the enrolment secret should not be displayed on the verification page

--- a/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
+++ b/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
@@ -13,22 +13,27 @@ Feature: Enrol a TOTP app from the verification page when two-factor auth is enf
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
     And using OCS API version "2"
+    # the admin group has to stay excluded, otherwise the enforcement applies to
+    # the administrator as well and every admin request the test framework makes
+    # is answered with 401 Unauthorised
+    And the administrator has added config key "enforce_2fa_excluded_groups" with value '["admin"]' in app "core"
     And the administrator has added config key "enforce_2fa" with value "yes" in app "core"
+    And the user has browsed to the login page
 
 
   Scenario: The QR code and the secret are both shown on the verification page
-    When user "Alice" logs in using the webUI after a redirect from the "VerificationPage" page
+    When user "Alice" logs in using the webUI after a redirect from the "verification" page
     Then the secret code from the QR code should match the one displayed on the verification page
 
 
   Scenario: A user who cannot scan the QR code can enrol using the displayed secret
-    Given user "Alice" has logged in using the webUI after a redirect from the "VerificationPage" page
+    Given user "Alice" has logged in using the webUI after a redirect from the "verification" page
     When the user adds one-time key generated from the secret displayed on the verification page
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
 
   Scenario: The secret is no longer disclosed once the user has enrolled
-    Given user "Alice" has logged in using the webUI after a redirect from the "VerificationPage" page
+    Given user "Alice" has logged in using the webUI after a redirect from the "verification" page
     And the user has added one-time key generated from the secret displayed on the verification page
     When the user re-logs in as "Alice" to the two-factor authentication verification page
     Then the enrolment secret should not be displayed on the verification page

--- a/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
+++ b/tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature
@@ -32,9 +32,12 @@ Feature: Enrol a TOTP app from the verification page when two-factor auth is enf
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
 
+  # the "has logged in ... after a redirect from" step cannot be used to arrange
+  # this: it asserts that the login ended up on the Files page, which by
+  # definition it does not when the user is redirected to the challenge page
   Scenario: The secret is no longer disclosed once the user has enrolled
-    When user "Alice" logs in using the webUI after a redirect from the "verification" page
+    Given user "Alice" logs in using the webUI after a redirect from the "verification" page
     And the user adds one-time key generated from the secret displayed on the verification page
-    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+    And the user should be redirected to a webUI page with the title "Files - %productname%"
     When the user re-logs in as "Alice" to the two-factor authentication verification page
     Then the enrolment secret should not be displayed on the verification page

--- a/tests/unit/Provider/TotpProviderTest.php
+++ b/tests/unit/Provider/TotpProviderTest.php
@@ -62,4 +62,41 @@ class TotpProviderTest extends TestCase {
 			->with($this->user, '111111');
 		$this->totpProvider->verifyChallenge($this->user, '111111');
 	}
+
+	/**
+	 * An unverified secret means the user still has to enroll their TOTP app
+	 * from the challenge page - which is the only page they get when 2FA is
+	 * enforced. Both the QR code and the secret itself have to be handed to
+	 * the template, so that users who cannot scan a QR code are still able to
+	 * enroll.
+	 */
+	public function testGetTemplateShowsQrAndSecretForUnverifiedSecret() {
+		$this->totp->method('getSecretInfo')
+			->with($this->user)
+			->willReturn(['secret' => 'MYTOTPSECRET', 'verified' => false]);
+		$this->otpGen->method('generateOtpQR')
+			->with($this->user, 'MYTOTPSECRET')
+			->willReturn('data:image/png;base64,QRCODE');
+
+		$page = $this->totpProvider->getTemplate($this->user)->fetchPage();
+
+		$this->assertStringContainsString('data:image/png;base64,QRCODE', $page);
+		$this->assertStringContainsString('MYTOTPSECRET', $page);
+	}
+
+	/**
+	 * A verified secret means the app is already enrolled - neither the QR
+	 * code nor the secret may be disclosed on the challenge page.
+	 */
+	public function testGetTemplateHidesSecretForVerifiedSecret() {
+		$this->totp->method('getSecretInfo')
+			->with($this->user)
+			->willReturn(['secret' => 'MYTOTPSECRET', 'verified' => true]);
+		$this->otpGen->expects($this->never())
+			->method('generateOtpQR');
+
+		$page = $this->totpProvider->getTemplate($this->user)->fetchPage();
+
+		$this->assertStringNotContainsString('MYTOTPSECRET', $page);
+	}
 }


### PR DESCRIPTION
## Description

When two-factor auth is enforced (`occ config:app:set core enforce_2fa --value "yes"`), a user who has never configured TOTP is redirected straight to `/login/challenge/totp` and cannot reach *Personal → Security*. The challenge page offered **only** the QR code — so a user who is unable to scan one (no camera, a desktop TOTP client, a password manager, accessibility needs) had no way to enrol and was effectively locked out.

`TotpProvider::getTemplate()` already computed `$secret` but only handed `qr` to the template:

```php
if (!$verified) {
    $tmpl->assign('isConfigured', false);
    $tmpl->assign('qr', $this->otpGen->generateOtpQR($user, $secret));
    // $secret was in scope but never assigned
}
```

The personal-settings path works because `SettingsController::enable()` returns `['enabled', 'secret', 'qr']` and `js/settingsview.js` prints the secret explicitly. The challenge page never got it.

## Changes

- `lib/Provider/TotpProvider.php` — assign `secret` alongside `qr` when the secret is not verified.
- `templates/challenge.php` — render it next to the QR code. This reuses the **existing** translatable string `This is your new TOTP secret:` from the personal settings panel, so no new l10n work is needed (already translated in every shipped locale).

Nothing is disclosed to a user who has a verified secret — the whole block stays behind `if (!$_['isConfigured'])`, unchanged.

## Tests

- **Unit** (`tests/unit/Provider/TotpProviderTest.php`) — two tests, written before the fix: the unverified case asserts both the QR and the secret reach the rendered template; the verified case asserts the secret is absent and `generateOtpQR` is never called. `getTemplate()` had **no** test before, which is how #292 shipped this gap.
- **Acceptance** (`tests/acceptance/features/webUITwoFactorTOTP/enforcedTwoFactorEnrolment.feature`) — a new webUI feature for the enforced-2FA enrolment path, which had no coverage anywhere in the repo: the displayed secret matches the one encoded in the QR code, a user can enrol from the challenge page using only the displayed secret, and the secret is no longer shown once enrolled. `enforce_2fa` is cleared in an `@enforce-2fa`-tagged `AfterScenario` hook so it cannot leak into other scenarios.

`make test-php-style`, `test-php-phpstan` and `test-php-phan` are clean; unit suite is `OK (41 tests, 88 assertions)`.

Two things worth knowing about the acceptance feature, both of them surprises:

- `enforce_2fa` applies to the **administrator** as well, so with it set every admin OCS request the test framework makes (user cleanup, file-lock clearing, the `occ` calls in the hook itself) comes back `401 Unauthorised`. The feature therefore also sets `enforce_2fa_excluded_groups` to `["admin"]`, and deletes it again afterwards.
- The **`Given`** variant of core's step `user ... has logged in using the webUI after a redirect from the ... page` is broken and cannot work for any page: it logs in via `userLogInAfterRedirectFromThePage()`, which deliberately does not assign `WebUILoginContext::$filesPage` (the login does not land on Files — that is the point of the step), and then calls `webUILoginShouldHaveBeenSuccessful()`, which reads that property, giving `Typed property WebUILoginContext::$filesPage must not be accessed before initialization`. `$filesPage` has exactly one assignment in that class (in `logInWithUsernameAndPasswordUsingTheWebUI()`), so both `@Given` redirect variants are affected, and these scenarios were their only users anywhere in core or its apps. They therefore bind to the working `@When`-annotated definition — using `Given` as the Gherkin keyword where the step is arrangement, since the keyword is independent of the annotation. Worth fixing in core separately.

## Verification

Reproduced and fixed end-to-end against a real ownCloud 11 instance with `enforce_2fa=yes`: before the change the template received only `requesttoken,isConfigured,qr,redirect_url`; after it, the secret renders, and a TOTP computed from the string shown on the page authenticates successfully (`200 → /apps/files/`).

## Security note

The secret is shown on a page reached **after** the first factor has been verified, and only to a user who has no verified secret yet. The QR code already on that page encodes the same secret, so this discloses nothing that was not already on screen — it only makes it readable to people who cannot scan a QR code.

Fixes #316. Reported downstream as SE-1745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


