### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - xxxx-xx-xx
 
+
+## [0.10.2] - 2026-07-29
+
 ### Fixed
 - [#340](https://github.com/owncloud/twofactor_totp/pull/340) - fix: show the TOTP secret next to the QR code on the challenge page
 
@@ -162,7 +165,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - App is now signed
 
-[Unreleased]: https://github.com/owncloud/twofactor_totp/compare/v0.10.1..master
+[Unreleased]: https://github.com/owncloud/twofactor_totp/compare/v0.10.2..master
+[0.10.2]: https://github.com/owncloud/twofactor_totp/compare/v0.10.1..v0.10.2
 [0.10.1]: https://github.com/owncloud/twofactor_totp/compare/v0.10.0..v0.10.1
 [0.10.0]: https://github.com/owncloud/twofactor_totp/compare/v0.9.0..v0.10.0
 [0.9.0]: https://github.com/owncloud/twofactor_totp/compare/v0.8.1...v0.9.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 This extension provides the most simple way to add a second factor to user logins. More sophisticated 2-Factor Authentication mechanisms with additional authentication devices is available via the [PrivacyIDEA ownCloud App](https://marketplace.owncloud.com/apps/twofactor_privacyidea) or by integrating other Identity Providers that offer multi-factor authenication mechanisms.</description>
 	<licence>AGPL</licence>
 	<author>ownCloud GmbH, Christoph Wurst, Semih Serhat Karakaya</author>
-	<version>0.10.1</version>
+	<version>0.10.2</version>
 	<namespace>TwoFactor_Totp</namespace>
 	<category>security</category>
 	<documentation>


### PR DESCRIPTION
Release preparation for **v0.10.2**.

## Changes

- `appinfo/info.xml` — `<version>` 0.10.1 → 0.10.2
- `CHANGELOG.md` — move the `Unreleased` entry under a dated `[0.10.2]` heading and add the compare links

## Contents of this release

One user-visible fix, [#340](https://github.com/owncloud/twofactor_totp/pull/340): under `enforce_2fa`, a user who has never configured TOTP is sent straight to the challenge page and cannot reach the personal security settings, but that page offered only the QR code — so anyone unable to scan one had no way to enrol. The secret is now shown next to the QR code, as it already was in the personal settings, and is still never shown to a user with a verified secret. Also closes the long-standing [#316](https://github.com/owncloud/twofactor_totp/issues/316).

Patch level: a bug fix with no API, schema or feature change.

## Verification

`make dist` was run locally against this branch — the tarball reports `<version>0.10.2</version>`, contains both halves of the fix, and ships no `tests/` or `vendor-bin/` directories. Signing is skipped locally; the release workflow signs with the G2 certificate and asserts the envelope and leaf CN.

Once this is merged, tagging `v0.10.2` on master triggers `.github/workflows/release.yml`, which verifies the tag matches `appinfo/info.xml` (hence the bump must land first), builds, signs and publishes the release with the tarball attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)